### PR TITLE
Add WaitInit function to Source

### DIFF
--- a/watch/source.go
+++ b/watch/source.go
@@ -86,11 +86,9 @@ func (s *source) run() {
 
 		err = s.w.Update(data)
 
-		if err == nil && !s.isInitialized() {
-			s.Lock()
+		if err == nil && !s.initialized {
 			close(s.ch)
 			s.initialized = true
-			s.Unlock()
 		}
 	}
 }
@@ -101,15 +99,7 @@ func (s *source) isClosed() bool {
 	return s.closed
 }
 
-func (s *source) isInitialized() bool {
-	s.RLock()
-	defer s.RUnlock()
-	return s.initialized
-}
-
 func (s *source) Initialized() <-chan struct{} {
-	s.RLock()
-	defer s.RUnlock()
 	return s.ch
 }
 

--- a/watch/source.go
+++ b/watch/source.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package watch
+package xwatch
 
 import (
 	"errors"

--- a/watch/source.go
+++ b/watch/source.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3x/log"
 )
 
+// ErrSourceClosed will be thrown from SourcePollFn to indicate that the Source should be closed
 var ErrSourceClosed = errors.New("source closed")
 
 // SourcePollFn provides source data

--- a/watch/source_test.go
+++ b/watch/source_test.go
@@ -32,14 +32,14 @@ import (
 
 func TestInitialized(t *testing.T) {
 	s := NewSource(&testSourceInput{callCount: 0, errAfter: 0, closeAfter: 10}, xlog.SimpleLogger)
-	assert.False(t, s.(*source).initialized)
 	s.Close()
+	assert.False(t, s.(*source).initialized)
 
-	ch := s.Initialized()
+	ch := s.WaitInit()
 	select {
 	case _ = <-ch:
 		assert.Fail(t, "initialized channel should be blocked")
-	case <-time.After(time.Millisecond):
+	case <-time.After(10 * time.Millisecond):
 	}
 }
 
@@ -87,7 +87,7 @@ func testSource(t *testing.T, errAfter int32, closeAfter int32, watchNum int) {
 		for !s.(*source).isClosed() {
 			time.Sleep(time.Millisecond)
 		}
-		ch := s.Initialized()
+		ch := s.WaitInit()
 		ok := true
 		select {
 		case _, ok = <-ch:

--- a/watch/source_test.go
+++ b/watch/source_test.go
@@ -32,8 +32,8 @@ import (
 
 func TestInitialized(t *testing.T) {
 	s := NewSource(&testSourceInput{callCount: 0, errAfter: 0, closeAfter: 10}, xlog.SimpleLogger)
+	assert.False(t, s.(*source).initialized)
 	s.Close()
-	assert.False(t, s.(*source).isInitialized())
 
 	ch := s.Initialized()
 	select {

--- a/watch/source_test.go
+++ b/watch/source_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package watch
+package xwatch
 
 import (
 	"errors"

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package watch
+package xwatch
 
 import (
 	"errors"

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package watch
+package xwatch
 
 import (
 	"fmt"


### PR DESCRIPTION
Add a Initialized function to expose the status of the source, so the users can wait on it to be initialized if needed.