### PR TITLE
Updating watchable functionality for new watches

### DIFF
--- a/watch/watch.go
+++ b/watch/watch.go
@@ -82,6 +82,10 @@ func (w *watchable) Watch() (interface{}, Watch, error) {
 	}
 
 	c := make(chan struct{}, 1)
+	if w.value != nil {
+		c <- struct{}{}
+	}
+
 	w.active = append(w.active, c)
 	closeFn := w.closeFunc(c)
 	w.Unlock()

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -95,6 +95,24 @@ func TestWatch(t *testing.T) {
 	_, ok = <-s.C()
 	assert.False(t, ok)
 	assert.Equal(t, 0, WatchLen(p.(*watchable)))
+
+	// second watch has initial update
+	p = NewWatchable()
+	_, first, err := p.Watch()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(first.C()))
+
+	p.Update(get)
+	<-first.C()
+	assert.Equal(t, get, first.Get())
+	assert.Equal(t, 0, len(first.C()))
+
+	_, second, err := p.Watch()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(first.C()))
+	<-second.C()
+	assert.Equal(t, get, second.Get())
+	assert.Equal(t, 0, len(second.C()))
 }
 
 func TestMultiWatch(t *testing.T) {


### PR DESCRIPTION
Updating the watchable functionality for creating watches - giving an initial update to the created watch if the watchable has a value.