### PR TITLE
Make bucketized pools more generic

### DIFF
--- a/pool/bucketized.go
+++ b/pool/bucketized.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pool
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/uber-go/tally"
+)
+
+type bucketPool struct {
+	capacity int
+	pool     ObjectPool
+}
+
+type bucketizedObjectPool struct {
+	sizesAsc          []Bucket
+	buckets           []bucketPool
+	maxBucketCapacity int
+	opts              ObjectPoolOptions
+	alloc             BucketizedAllocator
+	maxAlloc          tally.Counter
+}
+
+// NewBucketizedObjectPool creates a bucketized object pool
+func NewBucketizedObjectPool(sizes []Bucket, opts ObjectPoolOptions) BucketizedObjectPool {
+	if opts == nil {
+		opts = NewObjectPoolOptions()
+	}
+
+	sizesAsc := make([]Bucket, len(sizes))
+	copy(sizesAsc, sizes)
+	sort.Sort(BucketByCapacity(sizesAsc))
+
+	var maxBucketCapacity int
+	if len(sizesAsc) != 0 {
+		maxBucketCapacity = sizesAsc[len(sizesAsc)-1].Capacity
+	}
+
+	iopts := opts.InstrumentOptions()
+
+	return &bucketizedObjectPool{
+		opts:              opts,
+		sizesAsc:          sizesAsc,
+		maxBucketCapacity: maxBucketCapacity,
+		maxAlloc:          iopts.MetricsScope().Counter("alloc-max"),
+	}
+}
+
+func (p *bucketizedObjectPool) Init(alloc BucketizedAllocator) {
+	buckets := make([]bucketPool, len(p.sizesAsc))
+	for i := range p.sizesAsc {
+		size := p.sizesAsc[i].Count
+		capacity := p.sizesAsc[i].Capacity
+
+		opts := p.opts.SetSize(size)
+		iopts := opts.InstrumentOptions()
+
+		if iopts.MetricsScope() != nil {
+			opts = opts.SetInstrumentOptions(iopts.SetMetricsScope(
+				iopts.MetricsScope().Tagged(map[string]string{
+					"bucket-capacity": fmt.Sprintf("%d", capacity),
+				})))
+		}
+
+		buckets[i].capacity = capacity
+		buckets[i].pool = NewObjectPool(opts)
+		buckets[i].pool.Init(func() interface{} {
+			return alloc(capacity)
+		})
+	}
+	p.buckets = buckets
+	p.alloc = alloc
+}
+
+func (p *bucketizedObjectPool) Get(capacity int) interface{} {
+	if capacity > p.maxBucketCapacity {
+		p.maxAlloc.Inc(1)
+		return p.alloc(capacity)
+	}
+	for i := range p.buckets {
+		if p.buckets[i].capacity >= capacity {
+			return p.buckets[i].pool.Get()
+		}
+	}
+	return p.alloc(capacity)
+}
+
+func (p *bucketizedObjectPool) Put(obj interface{}, capacity int) {
+	if capacity > p.maxBucketCapacity {
+		return
+	}
+
+	for i := len(p.buckets) - 1; i >= 0; i-- {
+		if capacity >= p.buckets[i].capacity {
+			p.buckets[i].pool.Put(obj)
+			return
+		}
+	}
+}

--- a/pool/bytes_test.go
+++ b/pool/bytes_test.go
@@ -29,7 +29,6 @@ import (
 func TestBytesPool(t *testing.T) {
 	p := getBytesPool(2, []int{5, 10})
 	p.Init()
-	assert.Equal(t, 2, len(p.buckets))
 
 	b1 := p.Get(1)
 	assert.Equal(t, 0, len(b1))

--- a/pool/types.go
+++ b/pool/types.go
@@ -92,6 +92,21 @@ func (x BucketByCapacity) Less(i, j int) bool {
 	return x[i].Capacity < x[j].Capacity
 }
 
+// BucketizedAllocator allocates an object for a bucket given its capacity
+type BucketizedAllocator func(capacity int) interface{}
+
+// BucketizedObjectPool is a bucketized pool of objects
+type BucketizedObjectPool interface {
+	// Init initializes the pool
+	Init(alloc BucketizedAllocator)
+
+	// Get provides an object from the pool
+	Get(capacity int) interface{}
+
+	// Put returns an object to the pool, given the object capacity
+	Put(obj interface{}, capacity int)
+}
+
 // BytesPool provides a pool for variable size buffers
 type BytesPool interface {
 	// Init initializes the pool
@@ -103,4 +118,3 @@ type BytesPool interface {
 	// Put returns a buffer to the pool
 	Put(buffer []byte)
 }
-


### PR DESCRIPTION
cc @robskillington @kobolog 

This PR makes bucketized pools (i.e., pools that allocate objects with different capacities) more generic so they can be used as the underlying pool types for other types.