### PR TITLE
Add ability to bound the maximum backoff delay for retries

### DIFF
--- a/pool/heap_test.go
+++ b/pool/heap_test.go
@@ -78,7 +78,7 @@ func TestNativeHeapGetZero(t *testing.T) {
 		Bucket{Capacity: 256, Count: 2},
 	}, nil)
 
-	assert.Equal(t, []byte(nil), p.Get(0))
+	assert.Equal(t, []byte(nil), heap.Get(0))
 }
 
 func BenchmarkNativeHeap(b *testing.B) {

--- a/retry/options.go
+++ b/retry/options.go
@@ -21,6 +21,7 @@
 package xretry
 
 import (
+	"math"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -29,7 +30,8 @@ import (
 const (
 	defaultInitialBackoff = time.Second
 	defaultBackoffFactor  = 2.0
-	defaultMax            = 2
+	defaultMaxBackoff     = time.Duration(math.MaxInt64)
+	defaultMaxRetries     = 2
 	defaultJitter         = true
 )
 
@@ -37,7 +39,8 @@ type options struct {
 	scope          tally.Scope
 	initialBackoff time.Duration
 	backoffFactor  float64
-	max            int
+	maxBackoff     time.Duration
+	maxRetries     int
 	jitter         bool
 }
 
@@ -47,7 +50,8 @@ func NewOptions() Options {
 		scope:          tally.NoopScope,
 		initialBackoff: defaultInitialBackoff,
 		backoffFactor:  defaultBackoffFactor,
-		max:            defaultMax,
+		maxBackoff:     defaultMaxBackoff,
+		maxRetries:     defaultMaxRetries,
 		jitter:         defaultJitter,
 	}
 }
@@ -82,14 +86,24 @@ func (o *options) BackoffFactor() float64 {
 	return o.backoffFactor
 }
 
-func (o *options) SetMax(value int) Options {
+func (o *options) SetMaxBackoff(value time.Duration) Options {
 	opts := *o
-	opts.max = value
+	opts.maxBackoff = value
 	return &opts
 }
 
-func (o *options) Max() int {
-	return o.max
+func (o *options) MaxBackoff() time.Duration {
+	return o.maxBackoff
+}
+
+func (o *options) SetMaxRetries(value int) Options {
+	opts := *o
+	opts.maxRetries = value
+	return &opts
+}
+
+func (o *options) MaxRetries() int {
+	return o.maxRetries
 }
 
 func (o *options) SetJitter(value bool) Options {

--- a/retry/types.go
+++ b/retry/types.go
@@ -73,11 +73,17 @@ type Options interface {
 	// BackoffFactor gets the backoff factor multiplier when moving to next attempt
 	BackoffFactor() float64
 
-	// SetMax sets the maximum retry attempts
-	SetMax(value int) Options
+	// SetMaxBackoff sets the maximum backoff delay
+	SetMaxBackoff(value time.Duration) Options
+
+	// MaxBackoff returns the maximum backoff delay
+	MaxBackoff() time.Duration
+
+	// SetMaxRetries sets the maximum retry attempts
+	SetMaxRetries(value int) Options
 
 	// Max gets the maximum retry attempts
-	Max() int
+	MaxRetries() int
 
 	// SetJitter sets whether to jitter between the current backoff and the next
 	// backoff when moving to next attempt


### PR DESCRIPTION
cc @robskillington @kobolog @cw9 

This PR adds a parameter to the retrier options to bound the maximum backoff delay during retries.