### PR TITLE
Add utility function to start server-side accept loops

### DIFF
--- a/net/server.go
+++ b/net/server.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package net
+package xnet
 
 import (
 	"net"

--- a/net/server.go
+++ b/net/server.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package net
+
+import (
+	"net"
+
+	"github.com/m3db/m3x/errors"
+	"github.com/m3db/m3x/retry"
+)
+
+// StartAcceptLoop starts an accept loop for the given listener,
+// returning accepted connections via a channel while handling
+// temporary network errors. Fatal errors are returned via the
+// error channel with the listener closed on return
+func StartAcceptLoop(l net.Listener, retrier xretry.Retrier) (<-chan net.Conn, <-chan error) {
+	var (
+		connCh = make(chan net.Conn)
+		errCh  = make(chan error)
+	)
+
+	go func() {
+		defer l.Close()
+
+		for {
+			var conn net.Conn
+			if err := retrier.Attempt(func() error {
+				var connErr error
+				conn, connErr = l.Accept()
+				if connErr == nil {
+					return nil
+				}
+				// If the error is a temporary network error, we consider it retryable
+				if ne, ok := connErr.(net.Error); ok && ne.Temporary() {
+					return xerrors.NewRetryableError(ne)
+				}
+				// Otherwise it's a non-retryable error
+				return connErr
+			}); err != nil {
+				close(connCh)
+				errCh <- err
+				close(errCh)
+				return
+			}
+			connCh <- conn
+		}
+	}()
+
+	return connCh, errCh
+}

--- a/net/server_test.go
+++ b/net/server_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package net
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/m3db/m3x/retry"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartAcceptLoop(t *testing.T) {
+	var (
+		results        []string
+		resultLock     sync.Mutex
+		wgClient       sync.WaitGroup
+		wgServer       sync.WaitGroup
+		numConnections = 10
+		retrier        = xretry.NewRetrier(xretry.NewOptions())
+	)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	connCh, errCh := StartAcceptLoop(l, retrier)
+
+	wgServer.Add(1)
+	go func() {
+		defer wgServer.Done()
+
+		curr := 0
+		for conn := range connCh {
+			fmt.Fprintf(conn, "%d", curr)
+			conn.Close()
+			curr++
+		}
+	}()
+
+	for i := 0; i < numConnections; i++ {
+		wgClient.Add(1)
+		go func() {
+			defer wgClient.Done()
+
+			conn, err := net.Dial("tcp", l.Addr().String())
+			assert.Nil(t, err)
+
+			data, err := ioutil.ReadAll(conn)
+			assert.Nil(t, err)
+
+			resultLock.Lock()
+			results = append(results, string(data))
+			resultLock.Unlock()
+		}()
+	}
+
+	wgClient.Wait()
+
+	// Close the listener to intentionally cause a server-side connection error
+	l.Close()
+	wgServer.Wait()
+
+	sort.Strings(results)
+
+	var expected []string
+	for i := 0; i < numConnections; i++ {
+		expected = append(expected, fmt.Sprintf("%d", i))
+	}
+	assert.Equal(t, expected, results)
+
+	// Expect a server-side connection error
+	err = <-errCh
+	assert.NotNil(t, err)
+}

--- a/net/server_test.go
+++ b/net/server_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package net
+package xnet
 
 import (
 	"fmt"


### PR DESCRIPTION
cc @robskillington @martin-mao @kobolog @cw9 

This PR adds `StartAcceptLoop` function to start server-side accept loops, returning connections channel and error channel for handlers to consume.