### PR TITLE
Fix SetReportInterval() in instrument package

### DIFF
--- a/instrument/options.go
+++ b/instrument/options.go
@@ -83,7 +83,7 @@ func (o *options) MetricsSamplingRate() float64 {
 
 func (o *options) SetReportInterval(value time.Duration) Options {
 	opts := *o
-	o.reportInterval = value
+	opts.reportInterval = value
 	return &opts
 }
 


### PR DESCRIPTION
cc @cw9 @kobolog 

This PR fixes a bug in `SetReportInterval` in that the current implementation is setting the interval on the wrong option object.