### PR TITLE
Use program counters instead of stacks to track ref count usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.6
   - 1.7
 install:
   - go get -v github.com/Masterminds/glide

--- a/checked/debug.go
+++ b/checked/debug.go
@@ -23,19 +23,28 @@ package checked
 import (
 	"bytes"
 	"fmt"
-	"runtime/debug"
+	"runtime"
+	"sync"
 	"time"
 )
 
 const (
-	defaultTraceback       = false
-	defaultTracebackCycles = 3
+	defaultTraceback         = false
+	defaultTracebackCycles   = 3
+	defaultTracebackMaxDepth = 64
 )
 
 var (
-	traceback       = defaultTraceback
-	tracebackCycles = defaultTracebackCycles
-	panicFn         = defaultPanic
+	traceback            = defaultTraceback
+	tracebackCycles      = defaultTracebackCycles
+	tracebackMaxDepth    = defaultTracebackMaxDepth
+	tracebackCallersPool = sync.Pool{New: func() interface{} {
+		return make([]uintptr, tracebackMaxDepth)
+	}}
+	tracebackEntryPool = sync.Pool{New: func() interface{} {
+		return &debuggerEntry{}
+	}}
+	panicFn = defaultPanic
 )
 
 // PanicFn is a panic function to call on invalid checked state
@@ -68,6 +77,11 @@ func SetTraceback(value bool) {
 // SetTracebackCycles sets the count of traceback cycles to keep if enabled
 func SetTracebackCycles(value int) {
 	tracebackCycles = value
+}
+
+// SetTracebackMaxDepth sets the max amount of frames to capture for traceback
+func SetTracebackMaxDepth(frames int) {
+	tracebackMaxDepth = frames
 }
 
 func panicRef(c *RefCount, err error) {
@@ -114,24 +128,31 @@ type debugger struct {
 	entries [][]*debuggerEntry
 }
 
-func (d *debugger) append(event debuggerEvent, ref int, stack []byte) {
+func (d *debugger) append(event debuggerEvent, ref int, pc []uintptr) {
 	if len(d.entries) == 0 {
 		d.entries = make([][]*debuggerEntry, 1, tracebackCycles)
 	}
 	idx := len(d.entries) - 1
-	d.entries[idx] = append(d.entries[idx], &debuggerEntry{
-		event: event,
-		ref:   ref,
-		stack: stack,
-		t:     time.Now(),
-	})
+	entry := tracebackEntryPool.Get().(*debuggerEntry)
+	entry.event = event
+	entry.ref = ref
+	entry.pc = pc
+	entry.t = time.Now()
+	d.entries[idx] = append(d.entries[idx], entry)
 	if event == decRefEvent && ref == 0 {
 		if len(d.entries) == tracebackCycles {
 			// Shift all tracebacks back one if at end of traceback cycles
+			slice := d.entries[0]
+			for i, entry := range slice {
+				tracebackCallersPool.Put(entry.pc)
+				entry.pc = nil
+				tracebackEntryPool.Put(entry)
+				slice[i] = nil
+			}
 			for i := 1; i < len(d.entries); i++ {
 				d.entries[i-1] = d.entries[i]
 			}
-			d.entries[idx] = nil
+			d.entries[idx] = slice[:0]
 		} else {
 			// Begin writing new events to the next cycle
 			d.entries = d.entries[:len(d.entries)+1]
@@ -164,13 +185,30 @@ func (d *debuggerRef) Finalize() {
 type debuggerEntry struct {
 	event debuggerEvent
 	ref   int
-	stack []byte
+	pc    []uintptr
 	t     time.Time
 }
 
 func (e *debuggerEntry) String() string {
+	buf := bytes.NewBuffer(nil)
+	frames := runtime.CallersFrames(e.pc)
+	for {
+		frame, more := frames.Next()
+		buf.WriteString(frame.Function)
+		buf.WriteString("(...)")
+		buf.WriteString("\n")
+		buf.WriteString("\t")
+		buf.WriteString(frame.File)
+		buf.WriteString(":")
+		buf.WriteString(fmt.Sprintf("%d", frame.Line))
+		buf.WriteString(fmt.Sprintf(" +%x", frame.Entry))
+		buf.WriteString("\n")
+		if !more {
+			break
+		}
+	}
 	return fmt.Sprintf("%s, ref=%d, unixnanos=%d:\n%s\n",
-		e.event.String(), e.ref, e.t.UnixNano(), string(e.stack))
+		e.event.String(), e.ref, e.t.UnixNano(), buf.String())
 }
 
 func getDebuggerRef(c *RefCount) *debuggerRef {
@@ -191,16 +229,13 @@ func getDebuggerRef(c *RefCount) *debuggerRef {
 
 func tracebackEvent(c *RefCount, ref int, e debuggerEvent) {
 	d := getDebuggerRef(c)
-	stack := debug.Stack()
-	endlines := 0
-	skipPrologue := 1
+	depth := tracebackMaxDepth
+	pc := tracebackCallersPool.Get().([]uintptr)
+	if capacity := cap(pc); capacity < depth {
+		pc = make([]uintptr, depth)
+	}
+	pc = pc[:depth]
 	skipEntry := 2
-	entryLen := 2
-	skipAfterIdx := bytes.IndexFunc(stack, func(r rune) bool {
-		if r == '\n' {
-			endlines++
-		}
-		return endlines == skipPrologue+(skipEntry*entryLen)
-	})
-	d.append(e, ref, stack[skipAfterIdx+1:])
+	n := runtime.Callers(skipEntry, pc)
+	d.append(e, ref, pc[:n])
 }

--- a/checked/debug_test.go
+++ b/checked/debug_test.go
@@ -48,52 +48,55 @@ func TestTracebackReadAfterFree(t *testing.T) {
 	SetTracebackCycles(2)
 	defer SetTracebackCycles(defaultTracebackCycles)
 
-	elem := &struct {
-		RefCount
-		x int
-	}{
-		x: 42,
+	for i := 0; i < 1000; i++ {
+		elem := &struct {
+			RefCount
+			x int
+		}{
+			x: 42,
+		}
+
+		finalized := 0
+		elem.SetFinalizer(FinalizerFn(func() {
+			finalized++
+		}))
+
+		elem.IncRef()
+		assert.Equal(t, 1, elem.NumRef())
+		assert.Equal(t, 0, finalized)
+
+		elem.IncReads()
+		assert.Equal(t, 1, elem.NumReaders())
+
+		elem.DecReads()
+		assert.Equal(t, 0, elem.NumReaders())
+
+		elem.DecRef()
+		assert.Equal(t, 0, finalized)
+
+		elem.Finalize()
+		assert.Equal(t, 1, finalized)
+
+		var err error
+		SetPanicFn(func(e error) {
+			err = e
+		})
+
+		elem.IncReads()
+
+		require.Error(t, err)
+
+		ResetPanicFn()
+
+		str := err.Error()
+		assert.True(t, strings.Contains(str, "read after free: reads=1, ref=0"))
+		assert.True(t, strings.Contains(str, "IncReads, ref=0, unixnanos="))
+		assert.True(t, strings.Contains(str, "checked.(*RefCount).IncReads"))
+		assert.True(t, strings.Contains(str, "DecRef, ref=0, unixnanos="))
+		assert.True(t, strings.Contains(str, "checked.(*RefCount).DecRef"))
+		assert.True(t, strings.Contains(str, "IncRef, ref=1, unixnanos="))
+		assert.True(t, strings.Contains(str, "checked.(*RefCount).IncRef"))
 	}
-
-	finalized := 0
-	elem.SetFinalizer(FinalizerFn(func() {
-		finalized++
-	}))
-
-	elem.IncRef()
-	assert.Equal(t, 1, elem.NumRef())
-	assert.Equal(t, 0, finalized)
-
-	elem.IncReads()
-	assert.Equal(t, 1, elem.NumReaders())
-
-	elem.DecReads()
-	assert.Equal(t, 0, elem.NumReaders())
-
-	elem.DecRef()
-	assert.Equal(t, 0, finalized)
-
-	elem.Finalize()
-	assert.Equal(t, 1, finalized)
-
-	var err error
-	SetPanicFn(func(e error) {
-		err = e
-	})
-	defer ResetPanicFn()
-
-	elem.IncReads()
-
-	require.Error(t, err)
-
-	str := err.Error()
-	assert.True(t, strings.Contains(str, "read after free: reads=1, ref=0"))
-	assert.True(t, strings.Contains(str, "IncReads, ref=0, unixnanos="))
-	assert.True(t, strings.Contains(str, "checked.(*RefCount).IncReads"))
-	assert.True(t, strings.Contains(str, "DecRef, ref=0, unixnanos="))
-	assert.True(t, strings.Contains(str, "checked.(*RefCount).DecRef"))
-	assert.True(t, strings.Contains(str, "IncRef, ref=1, unixnanos="))
-	assert.True(t, strings.Contains(str, "checked.(*RefCount).IncRef"))
 }
 
 func TestTracebackDoubleWrite(t *testing.T) {
@@ -102,55 +105,58 @@ func TestTracebackDoubleWrite(t *testing.T) {
 	SetTracebackCycles(2)
 	defer SetTracebackCycles(defaultTracebackCycles)
 
-	elem := &struct {
-		RefCount
-		x int
-	}{
-		x: 42,
+	for i := 0; i < 1000; i++ {
+		elem := &struct {
+			RefCount
+			x int
+		}{
+			x: 42,
+		}
+
+		finalized := 0
+		elem.SetFinalizer(FinalizerFn(func() {
+			finalized++
+		}))
+
+		elem.IncRef()
+		elem.DecRef()
+		assert.Equal(t, 0, elem.NumRef())
+
+		elem.IncRef()
+		assert.Equal(t, 1, elem.NumRef())
+		assert.Equal(t, 0, finalized)
+
+		elem.IncWrites()
+		elem.DecWrites()
+		assert.Equal(t, 0, elem.NumWriters())
+
+		elem.DecRef()
+
+		elem.IncRef()
+		elem.MoveRef()
+		assert.Equal(t, 1, elem.NumRef())
+
+		var err error
+		SetPanicFn(func(e error) {
+			err = e
+		})
+
+		elem.IncWrites()
+		assert.Equal(t, 1, elem.NumWriters())
+
+		elem.IncWrites()
+
+		require.Error(t, err)
+
+		ResetPanicFn()
+
+		str := err.Error()
+		assert.True(t, strings.Contains(str, "double write: writes=2, ref=1"))
+		assert.True(t, strings.Contains(str, "IncWrites, ref=1, unixnanos="))
+		assert.True(t, strings.Contains(str, "checked.(*RefCount).IncWrites"))
+		assert.True(t, strings.Contains(str, "IncWrites, ref=1, unixnanos="))
+		assert.True(t, strings.Contains(str, "checked.(*RefCount).IncWrites"))
+		assert.True(t, strings.Contains(str, "IncRef, ref=1, unixnanos="))
+		assert.True(t, strings.Contains(str, "checked.(*RefCount).IncRef"))
 	}
-
-	finalized := 0
-	elem.SetFinalizer(FinalizerFn(func() {
-		finalized++
-	}))
-
-	elem.IncRef()
-	elem.DecRef()
-	assert.Equal(t, 0, elem.NumRef())
-
-	elem.IncRef()
-	assert.Equal(t, 1, elem.NumRef())
-	assert.Equal(t, 0, finalized)
-
-	elem.IncWrites()
-	elem.DecWrites()
-	assert.Equal(t, 0, elem.NumWriters())
-
-	elem.DecRef()
-
-	elem.IncRef()
-	elem.MoveRef()
-	assert.Equal(t, 1, elem.NumRef())
-
-	var err error
-	SetPanicFn(func(e error) {
-		err = e
-	})
-	defer ResetPanicFn()
-
-	elem.IncWrites()
-	assert.Equal(t, 1, elem.NumWriters())
-
-	elem.IncWrites()
-
-	require.Error(t, err)
-
-	str := err.Error()
-	assert.True(t, strings.Contains(str, "double write: writes=2, ref=1"))
-	assert.True(t, strings.Contains(str, "IncWrites, ref=1, unixnanos="))
-	assert.True(t, strings.Contains(str, "checked.(*RefCount).IncWrites"))
-	assert.True(t, strings.Contains(str, "IncWrites, ref=1, unixnanos="))
-	assert.True(t, strings.Contains(str, "checked.(*RefCount).IncWrites"))
-	assert.True(t, strings.Contains(str, "IncRef, ref=1, unixnanos="))
-	assert.True(t, strings.Contains(str, "checked.(*RefCount).IncRef"))
 }

--- a/checked/ref_test.go
+++ b/checked/ref_test.go
@@ -94,6 +94,23 @@ func TestRefCountFinalizeCallsFinalizer(t *testing.T) {
 	assert.Equal(t, 1, finalizerCalls)
 }
 
+func TestRefCountFinalizerNil(t *testing.T) {
+	elem := &RefCount{}
+
+	assert.Equal(t, (Finalizer)(nil), elem.Finalizer())
+
+	finalizerCalls := 0
+	elem.SetFinalizer(Finalizer(FinalizerFn(func() {
+		finalizerCalls++
+	})))
+
+	assert.NotNil(t, elem.Finalizer())
+
+	elem.Finalize()
+
+	assert.Equal(t, 1, finalizerCalls)
+}
+
 func TestRefCountReadAfterFree(t *testing.T) {
 	elem := &RefCount{}
 


### PR DESCRIPTION
cc @kobolog @xichen2020 @cw9 @martin-mao 