### PR TITLE
Track checked finalize events and use as the for marking traceback cycle end

### DIFF
--- a/checked/ref.go
+++ b/checked/ref.go
@@ -70,10 +70,17 @@ func (c *RefCount) NumRef() int {
 
 // Finalize will call the finalizer if any, ref count must be zero.
 func (c *RefCount) Finalize() {
-	if n := c.NumRef(); n != 0 {
+	n := c.NumRef()
+
+	if traceback {
+		tracebackEvent(c, int(n), finalizeEvent)
+	}
+
+	if n != 0 {
 		err := fmt.Errorf("finalize before zero ref count, ref=%d", n)
 		panicRef(c, err)
 	}
+
 	finalizerPtr := (*Finalizer)(atomic.LoadPointer(&c.finalizer))
 	if finalizerPtr != nil {
 		finalizer := *finalizerPtr


### PR DESCRIPTION
Before we were using a decref to ref zero as the traceback cycle end, however the true cycle end is when the owner finalizes the object (essentially calling it's destructor).  

This begins tracking it in the tracebacks and uses it as the cycle end instead of decref to ref zero.

cc @kobolog @xichen2020