### PR TITLE
Add leak detection support.

### DIFF
--- a/.ci/test-cover.sh
+++ b/.ci/test-cover.sh
@@ -11,7 +11,7 @@ echo "mode: count" > $TARGET
 echo "" > $LOG
 
 DIRS=""
-for DIR in $(find $SOURCE -maxdepth 10 -not -path '*/.git*' -not -path '*/.ci*' -not -path '*/_*' -not -path '*/vendor/*' -type d);
+for DIR in $(find $SOURCE -maxdepth 10 -not -path '*/.git*' -not -path '*/.ci*' -not -path '*/_*' -not -path '*/vendor/*' -not -path '*/.glide/*' -type d);
 do
   if ls $DIR/*_test.go &> /dev/null; then
     DIRS="$DIRS $DIR"

--- a/checked/bytes.go
+++ b/checked/bytes.go
@@ -54,6 +54,7 @@ func NewBytes(value []byte, opts BytesOptions) Bytes {
 		value: value,
 	}
 	b.SetFinalizer(b)
+	b.TrackObject(b.value)
 	return b
 }
 

--- a/checked/debug.go
+++ b/checked/debug.go
@@ -53,7 +53,7 @@ var tracebackEntryPool = sync.Pool{New: func() interface{} {
 
 var leaks struct {
 	sync.RWMutex
-	M map[string]uint64
+	m map[string]uint64
 }
 
 // PanicFn is a panic function to call on invalid checked state
@@ -110,7 +110,7 @@ func DumpLeaks() []string {
 
 	leaks.RLock()
 
-	for k, v := range leaks.M {
+	for k, v := range leaks.m {
 		r = append(r, fmt.Sprintf("leaked %d bytes, origin:\n%s", v, k))
 	}
 
@@ -303,5 +303,5 @@ func tracebackEvent(c *RefCount, ref int, e debuggerEvent) {
 }
 
 func init() {
-	leaks.M = make(map[string]uint64)
+	leaks.m = make(map[string]uint64)
 }

--- a/checked/debug_test.go
+++ b/checked/debug_test.go
@@ -43,8 +43,8 @@ func TestSetPanicFn(t *testing.T) {
 }
 
 func TestTracebackReadAfterFree(t *testing.T) {
-	SetTraceback(true)
-	defer SetTraceback(false)
+	EnableTracebacks()
+	defer DisableTracebacks()
 	SetTracebackCycles(2)
 	defer SetTracebackCycles(defaultTracebackCycles)
 
@@ -100,8 +100,8 @@ func TestTracebackReadAfterFree(t *testing.T) {
 }
 
 func TestTracebackDoubleWrite(t *testing.T) {
-	SetTraceback(true)
-	defer SetTraceback(defaultTraceback)
+	EnableTracebacks()
+	defer DisableTracebacks()
 	SetTracebackCycles(2)
 	defer SetTracebackCycles(defaultTracebackCycles)
 

--- a/checked/ref.go
+++ b/checked/ref.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
-	"sync"
 	"sync/atomic"
 	"unsafe"
 )
@@ -205,40 +204,4 @@ func (c *RefCount) TrackObject(v interface{}) {
 		leaks.M[origin] += uint64(size)
 		leaks.Unlock()
 	})
-}
-
-// EnableLeakDetection turns leak detection on.
-func EnableLeakDetection() {
-	atomic.StoreUint64(&leakDetectionFlag, 1)
-}
-
-// DisableLeakDetection turns leak detection off.
-func DisableLeakDetection() {
-	atomic.StoreUint64(&leakDetectionFlag, 0)
-}
-
-// DumpLeaks returns all detected leaks so far.
-func DumpLeaks() []string {
-	var r []string
-
-	leaks.RLock()
-
-	for k, v := range leaks.M {
-		r = append(r, fmt.Sprintf("leaked %d bytes, origin:\n%s", v, k))
-	}
-
-	leaks.RUnlock()
-
-	return r
-}
-
-var leakDetectionFlag uint64
-
-var leaks struct {
-	sync.RWMutex
-	M map[string]uint64
-}
-
-func init() {
-	leaks.M = make(map[string]uint64)
 }

--- a/checked/ref.go
+++ b/checked/ref.go
@@ -181,7 +181,7 @@ func (c *RefCount) TrackObject(v interface{}) {
 
 		leaks.Lock()
 		// Keep track of bytes leaked, not objects.
-		leaks.M[origin] += uint64(size)
+		leaks.m[origin] += uint64(size)
 		leaks.Unlock()
 	})
 }

--- a/checked/ref_test.go
+++ b/checked/ref_test.go
@@ -209,6 +209,7 @@ func TestRefCountWriteFinishAfterFree(t *testing.T) {
 
 func TestLeakDetection(t *testing.T) {
 	EnableLeakDetection()
+	defer DisableLeakDetection()
 
 	{
 		v := &RefCount{}

--- a/checked/ref_test.go
+++ b/checked/ref_test.go
@@ -22,7 +22,9 @@ package checked
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -203,4 +205,22 @@ func TestRefCountWriteFinishAfterFree(t *testing.T) {
 	elem.DecWrites()
 	assert.Error(t, err)
 	assert.Equal(t, "write finish after free: writes=0, ref=0", err.Error())
+}
+
+func TestLeakDetection(t *testing.T) {
+	EnableLeakDetection()
+
+	{
+		v := &RefCount{}
+		v.TrackObject(v)
+		v.IncRef()
+	}
+
+	runtime.GC()
+
+	// Finalizers are run in a separate goroutine, so we have to wait
+	// a little bit here.
+	time.Sleep(100 * time.Millisecond)
+
+	assert.NotEmpty(t, DumpLeaks())
 }

--- a/checked/ref_test.go
+++ b/checked/ref_test.go
@@ -218,9 +218,13 @@ func TestLeakDetection(t *testing.T) {
 
 	runtime.GC()
 
-	// Finalizers are run in a separate goroutine, so we have to wait
-	// a little bit here.
-	time.Sleep(100 * time.Millisecond)
+	var l []string
 
-	assert.NotEmpty(t, DumpLeaks())
+	for ; len(l) == 0; l = DumpLeaks() {
+		// Finalizers are run in a separate goroutine, so we have to wait
+		// a little bit here.
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	assert.NotEmpty(t, l)
 }

--- a/checked/types.go
+++ b/checked/types.go
@@ -55,6 +55,10 @@ type Ref interface {
 
 	// SetFinalizer sets the finalizer.
 	SetFinalizer(f Finalizer)
+
+	// TrackObject sets up the initial internal state of the Ref for
+	// leak detection.
+	TrackObject(v interface{})
 }
 
 // Read is an entity that checks reads.

--- a/pool/checked_object.go
+++ b/pool/checked_object.go
@@ -58,7 +58,9 @@ func NewCheckedObjectPool(opts ObjectPoolOptions) CheckedObjectPool {
 
 func (p *checkedObjectPool) Init(alloc CheckedAllocator) {
 	p.pool.Init(func() interface{} {
-		return alloc()
+		v := alloc()
+		v.TrackObject(v)
+		return v
 	})
 	p.finalizerPool.Init(func() interface{} {
 		return &checkedObjectFinalizer{}

--- a/pool/heap.go
+++ b/pool/heap.go
@@ -123,7 +123,6 @@ func (s *slot) getOr(l sync.Locker, fn OverflowFn) interface{} {
 			return nil
 		}); segment != nil {
 			l.Unlock()
-			s.updateMetrics()
 			return segment
 		}
 	}
@@ -186,6 +185,7 @@ func (p heap) pick(class int, action func(*slot)) bool {
 	for _, slot := range p.slots {
 		if class <= slot.class {
 			action(slot)
+			slot.updateMetrics()
 			return true
 		}
 	}


### PR DESCRIPTION
This PR adds support for leak detection tracking in checked objects by utilizing Go runtime finalizers. Essentially, each checked object can be marked for tracking by calling `Ref::TrackObject(v interface{})`, which will calculate the tracked allocation size and set a finalizer on the object that will determine whether it was garbage-collected while still having references. All detected leaks could then be queried with `DumpLeaks()` function.