### PR TITLE
Add DebugMutex

### DIFF
--- a/sync/debug_mutex.go
+++ b/sync/debug_mutex.go
@@ -8,29 +8,25 @@ import (
 	"time"
 )
 
-const _StackDepth = 16
-
 // DebugMutex is a RWMutex that tracks its ownership.
-type DebugMutex struct {
-	m sync.RWMutex
-}
+type DebugMutex sync.RWMutex
 
 // RLock locks DebugMutex for reading.
-func (m *DebugMutex) RLock() { m.m.RLock() }
+func (m *DebugMutex) RLock() { (*sync.RWMutex)(m).RLock() }
 
 // RUnlock undoes a single RLock call.
-func (m *DebugMutex) RUnlock() { m.m.RUnlock() }
+func (m *DebugMutex) RUnlock() { (*sync.RWMutex)(m).RUnlock() }
 
 // Lock locks DebugMutex for writing.
 func (m *DebugMutex) Lock() {
-	m.m.Lock()
+	(*sync.RWMutex)(m).Lock()
 	insert(m)
 }
 
 // Unlock unlocks DebugMutex for writing.
 func (m *DebugMutex) Unlock() {
 	remove(m)
-	m.m.Unlock()
+	(*sync.RWMutex)(m).Unlock()
 }
 
 // RLocker returns a Locker interface implemented via calls to RLock
@@ -41,8 +37,8 @@ func (m *DebugMutex) RLocker() sync.Locker {
 
 type rlocker DebugMutex
 
-func (r *rlocker) Lock()   { r.m.RLock() }
-func (r *rlocker) Unlock() { r.m.RUnlock() }
+func (r *rlocker) Lock()   { (*sync.RWMutex)(r).RLock() }
+func (r *rlocker) Unlock() { (*sync.RWMutex)(r).RUnlock() }
 
 var mutexDebuggingFlag bool
 
@@ -55,6 +51,8 @@ func DisableMutexDebugging() {
 func EnableMutexDebugging() {
 	mutexDebuggingFlag = true
 }
+
+const _StackDepth = 16
 
 type lockInfo struct {
 	ts time.Time

--- a/sync/debug_mutex.go
+++ b/sync/debug_mutex.go
@@ -1,0 +1,118 @@
+package xsync
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+const _StackDepth = 16
+
+// DebugMutex is a RWMutex that tracks its ownership.
+type DebugMutex struct {
+	m sync.RWMutex
+}
+
+// RLock locks DebugMutex for reading.
+func (m *DebugMutex) RLock() { m.m.RLock() }
+
+// RUnlock undoes a single RLock call.
+func (m *DebugMutex) RUnlock() { m.m.RUnlock() }
+
+// Lock locks DebugMutex for writing.
+func (m *DebugMutex) Lock() {
+	m.m.Lock()
+	insert(m)
+}
+
+// Unlock unlocks DebugMutex for writing.
+func (m *DebugMutex) Unlock() {
+	remove(m)
+	m.m.Unlock()
+}
+
+// RLocker returns a Locker interface implemented via calls to RLock
+// and RUnlock.
+func (m *DebugMutex) RLocker() sync.Locker {
+	return (*rlocker)(m)
+}
+
+type rlocker DebugMutex
+
+func (r *rlocker) Lock()   { r.m.RLock() }
+func (r *rlocker) Unlock() { r.m.RUnlock() }
+
+var mutexDebuggingFlag bool
+
+// DisableMutexDebugging turns mutex debugging off.
+func DisableMutexDebugging() {
+	mutexDebuggingFlag = false
+}
+
+// EnableMutexDebugging turns mutex debugging on.
+func EnableMutexDebugging() {
+	mutexDebuggingFlag = true
+}
+
+var activeLocks struct {
+	sync.Mutex
+	m map[*DebugMutex][]uintptr
+}
+
+func insert(m *DebugMutex) {
+	if !mutexDebuggingFlag {
+		return
+	}
+
+	r := make([]uintptr, _StackDepth)
+	n := runtime.Callers(3, r)
+
+	activeLocks.Lock()
+	activeLocks.m[m] = r[:n]
+	activeLocks.Unlock()
+}
+
+func remove(m *DebugMutex) {
+	if !mutexDebuggingFlag {
+		return
+	}
+
+	activeLocks.Lock()
+	delete(activeLocks.m, m)
+	activeLocks.Unlock()
+}
+
+func owner(l []uintptr) string {
+	var (
+		b    = new(bytes.Buffer)
+		n    runtime.Frame
+		more = len(l) != 0
+	)
+
+	for f := runtime.CallersFrames(l); more; {
+		n, more = f.Next()
+		fmt.Fprintf(b, "%s:%d\n\t%s\n", n.File, n.Line, n.Function)
+	}
+
+	return b.String()
+}
+
+// DumpOwned returns all currently locked mutexes.
+func DumpOwned() []string {
+	var r []string
+
+	activeLocks.Lock()
+
+	for m, l := range activeLocks.m {
+		r = append(r, fmt.Sprintf("mutex @ %p\n%s", m, owner(l)))
+	}
+
+	activeLocks.Unlock()
+
+	return r
+}
+
+func init() {
+	activeLocks.m = make(map[*DebugMutex][]uintptr)
+}

--- a/sync/debug_mutex.go
+++ b/sync/debug_mutex.go
@@ -127,14 +127,14 @@ func callstack(skip int) []uintptr {
 
 func traceback(l []uintptr) string {
 	var (
-		b    = new(bytes.Buffer)
 		n    runtime.Frame
 		more = len(l) != 0
+		b    bytes.Buffer
 	)
 
 	for f := runtime.CallersFrames(l); more; {
 		n, more = f.Next()
-		fmt.Fprintf(b, "%s:%d\n\t%s\n", n.File, n.Line, n.Function)
+		fmt.Fprintf(&b, "%s:%d\n\t%s\n", n.File, n.Line, n.Function)
 	}
 
 	return b.String()

--- a/sync/debug_mutex_test.go
+++ b/sync/debug_mutex_test.go
@@ -12,19 +12,19 @@ func TestDebugMutex(t *testing.T) {
 
 	m := &DebugRWMutex{}
 
-	assert.Empty(t, DumpLocks())
+	assert.Empty(t, DumpLocks(0))
 
 	m.Lock()
-	assert.NotEmpty(t, DumpLocks())
+	assert.NotEmpty(t, DumpLocks(0))
 
 	m.Unlock()
-	assert.Empty(t, DumpLocks())
+	assert.Empty(t, DumpLocks(0))
 
 	m.RLock()
-	assert.Empty(t, DumpLocks())
+	assert.Empty(t, DumpLocks(0))
 
 	m.RUnlock()
-	assert.Empty(t, DumpLocks())
+	assert.Empty(t, DumpLocks(0))
 }
 
 func TestDebugMutexContention(t *testing.T) {

--- a/sync/debug_mutex_test.go
+++ b/sync/debug_mutex_test.go
@@ -10,7 +10,7 @@ func TestDebugMutex(t *testing.T) {
 	EnableMutexDebugging()
 	defer DisableMutexDebugging()
 
-	m := &DebugMutex{}
+	m := &DebugRWMutex{}
 
 	assert.Empty(t, DumpLocks())
 
@@ -25,4 +25,20 @@ func TestDebugMutex(t *testing.T) {
 
 	m.RUnlock()
 	assert.Empty(t, DumpLocks())
+}
+
+func TestDebugMutexContention(t *testing.T) {
+	SetMutexContentionTrigger(2)
+
+	EnableMutexDebugging()
+	defer DisableMutexDebugging()
+
+	m := &DebugRWMutex{}
+
+	m.RLock()
+	m.RLock()
+
+	assert.Panics(t, func() {
+		m.Lock()
+	})
 }

--- a/sync/debug_mutex_test.go
+++ b/sync/debug_mutex_test.go
@@ -1,0 +1,28 @@
+package xsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDebugMutex(t *testing.T) {
+	EnableMutexDebugging()
+	defer DisableMutexDebugging()
+
+	m := &DebugMutex{}
+
+	assert.Empty(t, DumpOwned())
+
+	m.Lock()
+	assert.NotEmpty(t, DumpOwned())
+
+	m.Unlock()
+	assert.Empty(t, DumpOwned())
+
+	m.RLock()
+	assert.Empty(t, DumpOwned())
+
+	m.RUnlock()
+	assert.Empty(t, DumpOwned())
+}

--- a/sync/debug_mutex_test.go
+++ b/sync/debug_mutex_test.go
@@ -12,17 +12,17 @@ func TestDebugMutex(t *testing.T) {
 
 	m := &DebugMutex{}
 
-	assert.Empty(t, DumpOwned())
+	assert.Empty(t, DumpLocks())
 
 	m.Lock()
-	assert.NotEmpty(t, DumpOwned())
+	assert.NotEmpty(t, DumpLocks())
 
 	m.Unlock()
-	assert.Empty(t, DumpOwned())
+	assert.Empty(t, DumpLocks())
 
 	m.RLock()
-	assert.Empty(t, DumpOwned())
+	assert.Empty(t, DumpLocks())
 
 	m.RUnlock()
-	assert.Empty(t, DumpOwned())
+	assert.Empty(t, DumpLocks())
 }


### PR DESCRIPTION
WIP. This PR adds a `DebugMutex` type – a special version of `sync.RWMutex` that tracks its (exclusive, for now) ownership.