### PR TITLE
Add square brackets around error string for Errors

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -248,6 +248,7 @@ type Errors []error
 // Error implements error.
 func (e Errors) Error() string {
 	buf := bytes.NewBuffer(nil)
+	buf.WriteString("[")
 	for i, err := range e {
 		if err == nil {
 			buf.WriteString("<nil>")
@@ -260,5 +261,6 @@ func (e Errors) Error() string {
 			buf.WriteString(", ")
 		}
 	}
+	buf.WriteString("]")
 	return buf.String()
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -65,6 +65,6 @@ func TestErrorsIsAnErrorAndFormatsErrors(t *testing.T) {
 		fmt.Errorf("some error: foo=2, bar=baz"),
 		fmt.Errorf("some other error: foo=42, bar=qux"),
 	})
-	assert.Equal(t, "<some error: foo=2, bar=baz>, "+
-		"<some other error: foo=42, bar=qux>", errs.Error())
+	assert.Equal(t, "[<some error: foo=2, bar=baz>, "+
+		"<some other error: foo=42, bar=qux>]", errs.Error())
 }


### PR DESCRIPTION
cc @robskillington @cw9 

Add "[]" around the error string for `Errors` type since it's a slice of errors