### PR TITLE
Add unsafe package to perform zero-allocation conversion from string to byte slice

### DIFF
--- a/unsafe/string.go
+++ b/unsafe/string.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xunsafe
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// ImmutableBytes represents an immutable byte slice
+type ImmutableBytes []byte
+
+// ToBytes converts a string to a byte slice with zero heap memory allocations.
+// The returned byte slice shares the same memory space as the string passed in.
+// It is the caller's responsibility to make sure the returned byte slice is not
+// modified in any way until end of life.
+func ToBytes(s string) ImmutableBytes {
+	if len(s) == 0 {
+		return nil
+	}
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+
+	// NB(xichen): it is important that we access s in the same expression
+	// where we assign the data pointer of the string header to the data
+	// pointer of the slice header to make sure the underlying bytes don't
+	// get GC'ed before the assignment happens.
+	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: sh.Data,
+		Len:  len(s),
+		Cap:  len(s),
+	}))
+}

--- a/unsafe/string_benchmark_test.go
+++ b/unsafe/string_benchmark_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xunsafe
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkToBytesSmallString(b *testing.B) {
+	str := "foobarbaz"
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_ = ToBytes(str)
+	}
+}
+
+func BenchmarkToBytesLargeString(b *testing.B) {
+	var buf bytes.Buffer
+	for i := 0; i < 65536; i++ {
+		buf.WriteByte(byte(i % 256))
+	}
+	str := buf.String()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_ = ToBytes(str)
+	}
+}

--- a/unsafe/string_test.go
+++ b/unsafe/string_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xunsafe
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToBytesSmallString(t *testing.T) {
+	str := "foobarbaz"
+	b := ToBytes(str)
+	require.Equal(t, []byte(str), []byte(b))
+	require.Equal(t, len(str), len(b))
+	require.Equal(t, len(str), cap(b))
+}
+
+func TestToBytesLargeString(t *testing.T) {
+	var buf bytes.Buffer
+	for i := 0; i < 65536; i++ {
+		buf.WriteByte(byte(i % 256))
+	}
+	str := buf.String()
+	b := ToBytes(str)
+	require.Equal(t, []byte(str), []byte(b))
+	require.Equal(t, len(str), len(b))
+	require.Equal(t, len(str), cap(b))
+}

--- a/unsafe/string_test.go
+++ b/unsafe/string_test.go
@@ -22,6 +22,7 @@ package xunsafe
 
 import (
 	"bytes"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -45,4 +46,22 @@ func TestToBytesLargeString(t *testing.T) {
 	require.Equal(t, []byte(str), []byte(b))
 	require.Equal(t, len(str), len(b))
 	require.Equal(t, len(str), cap(b))
+}
+
+func TestToBytesStillValidAfterStringIsGCed(t *testing.T) {
+	b := testStringToBytes()
+
+	// The source string is now out of scope, forcing a GC
+	runtime.GC()
+
+	// Assert the underlying byte slice is still valid
+	require.Equal(t, []byte("foobarbaz"), []byte(b))
+	require.Equal(t, 9, len(b))
+	require.Equal(t, 9, cap(b))
+}
+
+func testStringToBytes() []byte {
+	str := "foobarbaz"
+	b := ToBytes(str)
+	return b
 }


### PR DESCRIPTION
cc @kobolog @robskillington @jeromefroe @cw9 @prateek 

This PR adds the unsafe package to perform zero-allocation conversion from string to byte slices, which will significantly reduce GC when we need to encode string ids as byte slices.