### PR TITLE
Add unsafe function to convert a byte slice to string with no heap allocation

### DIFF
--- a/unsafe/bytes.go
+++ b/unsafe/bytes.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xunsafe
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// ToString converts a byte slice to a string with zero heap memory allocations.
+// The returned string shares the same memory space as the byte slice passed in.
+// It is the caller's responsibility to make sure the byte slice passed in is
+// not modified in any way until end of life.
+func ToString(b ImmutableBytes) string {
+	// NB(xichen): we need to declare a real string so internally the compiler knows
+	// to use an unsafe pointer to keep track of the underlying memory so that once
+	// the string's internal pointer is updated with the byte slice's pointer, the
+	// compiler won't prematurely GC the memory when the byte slice is out of scope.
+	var str string
+	if len(b) == 0 {
+		return str
+	}
+
+	// NB(xichen): this makes sure that even if GC relocates the byte slice's underlying
+	// memory after this assignment, the corresponding unsafe.Pointer in the internal
+	// string struct will be updated accordingly to reflect the memory relocation.
+	strHeader := (*reflect.StringHeader)(unsafe.Pointer(&str))
+	strHeader.Data = (*reflect.SliceHeader)(unsafe.Pointer(&b)).Data
+
+	// NB(xichen): it is important that we access b after assigning the data pointer
+	// of the slice header to the data pointer of the string header to make sure the
+	// bye slice doesn't get GC'ed before the assignment happens.
+	l := len(b)
+	strHeader.Len = l
+
+	// NB(xichen): it is not an issue if the byte slice's length and capacity disagree
+	// because GC does not use the header information to determine how much memory
+	// has been allocated. Instead, each address is mapped to a span internally by
+	// truncating the address to the page boundary and reverse looking up the span
+	// it belongs to, and each span has a fixed object size.
+	return str
+}

--- a/unsafe/bytes_benchmark_test.go
+++ b/unsafe/bytes_benchmark_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xunsafe
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkToStringSmallSlice(b *testing.B) {
+	slice := []byte("foobarbaz")
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_ = ToString(slice)
+	}
+}
+
+func BenchmarkToStringLargeSlice(b *testing.B) {
+	var buf bytes.Buffer
+	for i := 0; i < 65536; i++ {
+		buf.WriteByte(byte(i % 256))
+	}
+	slice := buf.Bytes()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_ = ToString(slice)
+	}
+}

--- a/unsafe/bytes_test.go
+++ b/unsafe/bytes_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xunsafe
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToStringSmallSlice(t *testing.T) {
+	b := []byte("foobarbaz")
+	str := ToString(b)
+	require.Equal(t, string(b), str)
+	require.Equal(t, len(b), len(str))
+}
+
+func TestToStringLargeSlice(t *testing.T) {
+	var buf bytes.Buffer
+	for i := 0; i < 65536; i++ {
+		buf.WriteByte(byte(i % 256))
+	}
+	b := buf.Bytes()
+	str := ToString(b)
+	require.Equal(t, string(b), str)
+	require.Equal(t, len(b), len(str))
+}
+
+func TestToStringStillValidAfterSliceIsGCed(t *testing.T) {
+	str := testBytesToString()
+
+	// The source byte slice is now out of scope, forcing a GC
+	runtime.GC()
+
+	// Assert the underlying byte slice is still valid
+	require.Equal(t, "foobarbaz", str)
+	require.Equal(t, 9, len(str))
+}
+
+func testBytesToString() string {
+	b := []byte("foobarbaz")
+	str := ToString(b)
+	return str
+}

--- a/unsafe/string.go
+++ b/unsafe/string.go
@@ -38,7 +38,7 @@ func ToBytes(s string) ImmutableBytes {
 	}
 
 	// NB(xichen): we need to declare a real byte slice so internally the compiler
-	// knows to use an unsafe.Pointer to keep track of the underlying memory so tha
+	// knows to use an unsafe.Pointer to keep track of the underlying memory so that
 	// once the slice's array pointer is updated with the pointer to the string's
 	// underlying bytes, the compiler won't prematurely GC the memory when the string
 	// goes out of scope.
@@ -52,7 +52,7 @@ func ToBytes(s string) ImmutableBytes {
 
 	// NB(xichen): it is important that we access s after we assign the Data
 	// pointer of the string header to the Data pointer of the slice header to
-	// make sure the string (and the underlying bytes backing the string) don't get
+	// make sure the string (and the underlying bytes backing the string) doesn't get
 	// GC'ed before the assignment happens.
 	l := len(s)
 	byteHeader.Len = l


### PR DESCRIPTION
cc @jeromefroe @kobolog @robskillington 

This PR adds an unsafe method to convert a byte slice to a string with zero heap allocation.