### PR TITLE
Pass a callback function to process byte array backing the string

### DIFF
--- a/unsafe/string.go
+++ b/unsafe/string.go
@@ -31,8 +31,8 @@ type ImmutableBytes []byte
 // BytesFn processes a byte slice
 type BytesFn func(ImmutableBytes)
 
-// BytesWithArgFn takes an argument alongside the byte slice
-type BytesWithArgFn func(ImmutableBytes, interface{})
+// BytesAndArgFn takes an argument alongside the byte slice
+type BytesAndArgFn func(ImmutableBytes, interface{})
 
 // WithBytes converts a string to a byte slice with zero heap memory allocations,
 // and calls a function to process the byte slice. It is the caller's responsibility
@@ -50,7 +50,7 @@ func WithBytes(s string, fn BytesFn) {
 // caller's responsibility to make sure the callback function passed in does not modify
 // the byte slice in any way, and holds no reference to the byte slice after the function
 // returns.
-func WithBytesAndArg(s string, arg interface{}, fn BytesWithArgFn) {
+func WithBytesAndArg(s string, arg interface{}, fn BytesAndArgFn) {
 	fn(toBytes(s), arg)
 }
 

--- a/unsafe/string.go
+++ b/unsafe/string.go
@@ -37,7 +37,7 @@ type BytesWithArgFn func(ImmutableBytes, interface{})
 // ForBytes converts a string to a byte slice with zero heap memory allocations,
 // and calls a function to process the byte slice. It is the caller's responsibility
 // to make sure the callback function passed in does not modify the byte slice
-// in any way.
+// in any way, and holds no reference to the byte slice after the function returns.
 func ForBytes(s string, fn BytesFn) {
 	// NB(xichen): regardless of whether the backing array is allocated on the heap
 	// or on the stack, it should still be valid before the string goes out of scope
@@ -48,7 +48,8 @@ func ForBytes(s string, fn BytesFn) {
 // ForBytesWithArg converts a string to a byte slice with zero heap memory allocations,
 // and calls a function to process the byte slice alongside one argument. It is the
 // caller's responsibility to make sure the callback function passed in does not modify
-// the byte slice in any way.
+// the byte slice in any way, and holds no reference to the byte slice after the function
+// returns.
 func ForBytesWithArg(s string, arg interface{}, fn BytesWithArgFn) {
 	fn(toBytes(s), arg)
 }

--- a/unsafe/string.go
+++ b/unsafe/string.go
@@ -34,23 +34,23 @@ type BytesFn func(ImmutableBytes)
 // BytesWithArgFn takes an argument alongside the byte slice
 type BytesWithArgFn func(ImmutableBytes, interface{})
 
-// ForBytes converts a string to a byte slice with zero heap memory allocations,
+// WithBytes converts a string to a byte slice with zero heap memory allocations,
 // and calls a function to process the byte slice. It is the caller's responsibility
 // to make sure the callback function passed in does not modify the byte slice
 // in any way, and holds no reference to the byte slice after the function returns.
-func ForBytes(s string, fn BytesFn) {
+func WithBytes(s string, fn BytesFn) {
 	// NB(xichen): regardless of whether the backing array is allocated on the heap
 	// or on the stack, it should still be valid before the string goes out of scope
 	// so it's safe to call the function on the underlying byte slice.
 	fn(toBytes(s))
 }
 
-// ForBytesWithArg converts a string to a byte slice with zero heap memory allocations,
+// WithBytesAndArg converts a string to a byte slice with zero heap memory allocations,
 // and calls a function to process the byte slice alongside one argument. It is the
 // caller's responsibility to make sure the callback function passed in does not modify
 // the byte slice in any way, and holds no reference to the byte slice after the function
 // returns.
-func ForBytesWithArg(s string, arg interface{}, fn BytesWithArgFn) {
+func WithBytesAndArg(s string, arg interface{}, fn BytesWithArgFn) {
 	fn(toBytes(s), arg)
 }
 

--- a/unsafe/string_benchmark_test.go
+++ b/unsafe/string_benchmark_test.go
@@ -30,7 +30,7 @@ func BenchmarkToBytesSmallString(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_ = ToBytes(str)
+		_ = toBytes(str)
 	}
 }
 
@@ -43,6 +43,6 @@ func BenchmarkToBytesLargeString(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_ = ToBytes(str)
+		_ = toBytes(str)
 	}
 }

--- a/unsafe/string_test.go
+++ b/unsafe/string_test.go
@@ -56,7 +56,7 @@ func TestForBytesWithArgLargeString(t *testing.T) {
 }
 
 func validateForBytes(t *testing.T, str string) {
-	ForBytes(str, func(b []byte) {
+	ForBytes(str, func(b ImmutableBytes) {
 		require.Equal(t, []byte(str), []byte(b))
 		require.Equal(t, len(str), len(b))
 		require.Equal(t, len(str), cap(b))
@@ -64,7 +64,7 @@ func validateForBytes(t *testing.T, str string) {
 }
 
 func validateForBytesWithArg(t *testing.T, str string) {
-	ForBytesWithArg(str, "cat", func(data []byte, arg interface{}) {
+	ForBytesWithArg(str, "cat", func(data ImmutableBytes, arg interface{}) {
 		var buf bytes.Buffer
 		for _, b := range data {
 			buf.WriteByte(b)

--- a/unsafe/string_test.go
+++ b/unsafe/string_test.go
@@ -27,44 +27,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestForBytesSmallString(t *testing.T) {
+func TestWithBytesSmallString(t *testing.T) {
 	str := "foobarbaz"
-	validateForBytes(t, str)
+	validateWithBytes(t, str)
 }
 
-func TestForBytesLargeString(t *testing.T) {
+func TestWithBytesLargeString(t *testing.T) {
 	var buf bytes.Buffer
 	for i := 0; i < 65536; i++ {
 		buf.WriteByte(byte(i % 256))
 	}
 	str := buf.String()
-	validateForBytes(t, str)
+	validateWithBytes(t, str)
 }
 
-func TestForBytesWithArgSmallString(t *testing.T) {
+func TestWithBytesAndArgSmallString(t *testing.T) {
 	str := "foobarbaz"
-	validateForBytesWithArg(t, str)
+	validateWithBytesAndArg(t, str)
 }
 
-func TestForBytesWithArgLargeString(t *testing.T) {
+func TestWithBytesAndArgLargeString(t *testing.T) {
 	var buf bytes.Buffer
 	for i := 0; i < 65536; i++ {
 		buf.WriteByte(byte(i % 256))
 	}
 	str := buf.String()
-	validateForBytesWithArg(t, str)
+	validateWithBytesAndArg(t, str)
 }
 
-func validateForBytes(t *testing.T, str string) {
-	ForBytes(str, func(b ImmutableBytes) {
+func validateWithBytes(t *testing.T, str string) {
+	WithBytes(str, func(b ImmutableBytes) {
 		require.Equal(t, []byte(str), []byte(b))
 		require.Equal(t, len(str), len(b))
 		require.Equal(t, len(str), cap(b))
 	})
 }
 
-func validateForBytesWithArg(t *testing.T, str string) {
-	ForBytesWithArg(str, "cat", func(data ImmutableBytes, arg interface{}) {
+func validateWithBytesAndArg(t *testing.T, str string) {
+	WithBytesAndArg(str, "cat", func(data ImmutableBytes, arg interface{}) {
 		var buf bytes.Buffer
 		for _, b := range data {
 			buf.WriteByte(b)


### PR DESCRIPTION
cc @jeromefroe @kobolog @robskillington 

This PR passes a callback function to process byte array backing the string without memory allocation. Because we are guaranteed that the string is in scope when the callback function is called, as long as the callback function doesn't mutate the byte slice and doesn't hold reference to the byte slice when it returns, it should be safe.