### PR TITLE
fix panic in NullLogger

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -142,13 +142,13 @@ func (nullLogger) Debug(msg string)                       {}
 func (l nullLogger) Fields() LogFields                    { return l.fields }
 
 func (l nullLogger) WithFields(newFields ...LogField) Logger {
+	existingLen := 0
+
 	existingFields := l.Fields()
-	if existingFields == nil {
-		existingFields = Fields([]LogField{})
-		l.fields = existingFields
+	if existingFields != nil {
+		existingLen = existingFields.Len()
 	}
 
-	existingLen := existingFields.Len()
 	fields := make([]LogField, 0, existingLen+len(newFields))
 	for i := 0; i < existingLen; i++ {
 		fields = append(fields, existingFields.ValueAt(i))

--- a/log/logger.go
+++ b/log/logger.go
@@ -122,7 +122,7 @@ func (f Fields) Len() int { return len(f) }
 func (f Fields) ValueAt(i int) LogField { return f[i] }
 
 // NullLogger is a logger that emits nowhere
-var NullLogger Logger = nullLogger{}
+var NullLogger Logger = nullLogger{fields: Fields([]LogField{})}
 
 type nullLogger struct {
 	fields LogFields

--- a/log/logger.go
+++ b/log/logger.go
@@ -122,7 +122,7 @@ func (f Fields) Len() int { return len(f) }
 func (f Fields) ValueAt(i int) LogField { return f[i] }
 
 // NullLogger is a logger that emits nowhere
-var NullLogger Logger = nullLogger{fields: Fields([]LogField{})}
+var NullLogger Logger = nullLogger{}
 
 type nullLogger struct {
 	fields LogFields
@@ -143,8 +143,14 @@ func (l nullLogger) Fields() LogFields                    { return l.fields }
 
 func (l nullLogger) WithFields(newFields ...LogField) Logger {
 	existingFields := l.Fields()
-	fields := make([]LogField, 0, existingFields.Len()+len(newFields))
-	for i := 0; i < existingFields.Len(); i++ {
+	if existingFields == nil {
+		existingFields = Fields([]LogField{})
+		l.fields = existingFields
+	}
+
+	existingLen := existingFields.Len()
+	fields := make([]LogField, 0, existingLen+len(newFields))
+	for i := 0; i < existingLen; i++ {
 		fields = append(fields, existingFields.ValueAt(i))
 	}
 	fields = append(fields, newFields...)

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -20,8 +20,11 @@
 
 package xlog
 
-import "testing"
-import "github.com/stretchr/testify/require"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestNullLogger(t *testing.T) {
 	require.NotPanics(t, func() {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xlog
+
+import "testing"
+import "github.com/stretchr/testify/require"
+
+func TestNullLogger(t *testing.T) {
+	require.NotPanics(t, func() {
+		NullLogger.WithFields(NewLogField("key", "value")).Info("msg")
+	})
+}


### PR DESCRIPTION
There was a panic when calling NullLogger.WithFields() because the
fields was nill

@xichen2020 @robskillington @prateek 