### PR TITLE
Add instrumentation and retry configurations

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: 9248400de3fc8b0e26b60a49a43e98d84b889c180b14ee49fde5806b92d3f9dd
-updated: 2017-04-13T15:38:23.167290985-04:00
+hash: fdb267e7d15df0b298df5ee4b12e5b8eb9bcef67e9881df6dd01b63abd2d7779
+updated: 2017-04-16T14:41:26.367919915-04:00
 imports:
+- name: github.com/apache/thrift
+  version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
+  subpackages:
+  - lib/go/thrift
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/golang/mock
@@ -10,8 +14,15 @@ imports:
   subpackages:
   - assert
   - require
+- name: github.com/uber-go/atomic
+  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
-  version: 08e86c3c1eb55364d563bd6beb982040225f4bb7
+  version: 4b9d9de43ffcb0b7efe67dab2a92c2d58dbf16ab
+  subpackages:
+  - m3
+  - m3/customtransports
+  - m3/thrift
+  - m3/thriftudp
 - name: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,9 +10,13 @@ import:
   - assert
   - require
 - package: github.com/uber-go/tally
-  version: 1.0.0
+  version: 3.0.0
 - package: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - package: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
+- package: github.com/apache/thrift
+  version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
+- package: github.com/uber-go/atomic
+  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 

--- a/instrument/config.go
+++ b/instrument/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/instrument/config.go
+++ b/instrument/config.go
@@ -29,27 +29,32 @@ import (
 	"github.com/uber-go/tally/m3"
 )
 
-const (
-	defaultSamplingRate      = 1.0
-	defaultReportingInterval = time.Second
-)
-
 var (
 	errNoReporterConfigured = errors.New("no reporter configured")
 )
 
 // ScopeConfiguration configures a metric scope.
 type ScopeConfiguration struct {
-	Prefix            string            `yaml:"prefix"`
-	ReportingInterval time.Duration     `yaml:"reportingInterval"`
-	CommonTags        map[string]string `yaml:"tags"`
+	// Prefix of metrics in this scope.
+	Prefix string `yaml:"prefix"`
+
+	// Metrics reporting interval.
+	ReportingInterval time.Duration `yaml:"reportingInterval"`
+
+	// Common tags shared by metrics reported.
+	CommonTags map[string]string `yaml:"tags"`
 }
 
 // MetricsConfiguration configures options for emitting metrics.
 type MetricsConfiguration struct {
-	RootScope    *ScopeConfiguration `yaml:"scope"`
-	M3Reporter   *m3.Configuration   `yaml:"m3"`
-	SamplingRate float64             `yaml:"samplingRate" validate:"nonzero,min=0.0,max=1.0"`
+	// Root scope configuration.
+	RootScope *ScopeConfiguration `yaml:"scope"`
+
+	// M3 reporter configuration.
+	M3Reporter *m3.Configuration `yaml:"m3"`
+
+	// Metrics sampling rate.
+	SamplingRate float64 `yaml:"samplingRate" validate:"nonzero,min=0.0,max=1.0"`
 }
 
 // NewRootScope creates a new tally.Scope based on a tally.CachedStatsReporter

--- a/instrument/config.go
+++ b/instrument/config.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package instrument
+
+import (
+	"errors"
+	"io"
+	"time"
+
+	"github.com/uber-go/tally"
+	"github.com/uber-go/tally/m3"
+)
+
+const (
+	defaultSamplingRate      = 1.0
+	defaultReportingInterval = time.Second
+)
+
+var (
+	errNoReporterConfigured = errors.New("no reporter configured")
+)
+
+// ScopeConfiguration configures a metric scope.
+type ScopeConfiguration struct {
+	Prefix            string            `yaml:"prefix"`
+	ReportingInterval time.Duration     `yaml:"reportingInterval"`
+	CommonTags        map[string]string `yaml:"tags"`
+}
+
+// MetricsConfiguration configures options for emitting metrics.
+type MetricsConfiguration struct {
+	RootScope    *ScopeConfiguration `yaml:"scope"`
+	M3Reporter   *m3.Configuration   `yaml:"m3"`
+	SamplingRate float64             `yaml:"samplingRate" validate:"nonzero,min=0.0,max=1.0"`
+}
+
+// NewRootScope creates a new tally.Scope based on a tally.CachedStatsReporter
+// based on the the the config.
+func (mc *MetricsConfiguration) NewRootScope() (tally.Scope, io.Closer, error) {
+	if mc.M3Reporter == nil {
+		return nil, nil, errNoReporterConfigured
+	}
+	r, err := mc.M3Reporter.NewReporter()
+	if err != nil {
+		return nil, nil, err
+	}
+	s, c := mc.NewRootScopeReporter(r)
+	return s, c, nil
+}
+
+// NewRootScopeReporter creates a new tally.Scope based on a given tally.CachedStatsReporter
+// and given root scope config. In most cases NewRootScope should be used, but for cases such
+// as hooking into the reporter to manually flush it.
+func (mc *MetricsConfiguration) NewRootScopeReporter(
+	r tally.CachedStatsReporter,
+) (tally.Scope, io.Closer) {
+	var (
+		prefix string
+		tags   map[string]string
+	)
+
+	if mc.RootScope != nil {
+		if mc.RootScope.Prefix != "" {
+			prefix = mc.RootScope.Prefix
+		}
+		if mc.RootScope.CommonTags != nil {
+			tags = mc.RootScope.CommonTags
+		}
+	}
+
+	scopeOpts := tally.ScopeOptions{
+		Tags:           tags,
+		Prefix:         prefix,
+		CachedReporter: r,
+	}
+	return tally.NewRootScope(scopeOpts, mc.ReportInterval())
+}
+
+// SampleRate returns the metrics sampling rate.
+func (mc *MetricsConfiguration) SampleRate() float64 {
+	if mc.SamplingRate > 0.0 && mc.SamplingRate <= 1.0 {
+		return mc.SamplingRate
+	}
+	return defaultSamplingRate
+}
+
+// ReportInterval returns the metrics reporting interval.
+func (mc *MetricsConfiguration) ReportInterval() time.Duration {
+	if mc.RootScope != nil && mc.RootScope.ReportingInterval != 0 {
+		return mc.RootScope.ReportingInterval
+	}
+	return defaultReportingInterval
+}

--- a/instrument/options.go
+++ b/instrument/options.go
@@ -28,6 +28,11 @@ import (
 	"github.com/uber-go/tally"
 )
 
+const (
+	defaultSamplingRate      = 1.0
+	defaultReportingInterval = time.Second
+)
+
 type options struct {
 	logger         xlog.Logger
 	scope          tally.Scope

--- a/instrument/options.go
+++ b/instrument/options.go
@@ -28,11 +28,6 @@ import (
 	"github.com/uber-go/tally"
 )
 
-const (
-	defaultSamplingRate   = 1.0
-	defaultReportInterval = time.Second
-)
-
 type options struct {
 	logger         xlog.Logger
 	scope          tally.Scope
@@ -47,7 +42,7 @@ func NewOptions() Options {
 		logger:         logger,
 		scope:          tally.NoopScope,
 		samplingRate:   defaultSamplingRate,
-		reportInterval: defaultReportInterval,
+		reportInterval: defaultReportingInterval,
 	}
 }
 

--- a/pool/config_test.go
+++ b/pool/config_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pool
+
+import (
+	"testing"
+
+	"github.com/m3db/m3x/instrument"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectPoolConfiguration(t *testing.T) {
+	cfg := ObjectPoolConfiguration{
+		Size: 1,
+		WaterMark: WaterMarkConfiguration{
+			RefillLowWaterMark:  0.1,
+			RefillHighWaterMark: 0.5,
+		},
+	}
+	opts := cfg.NewObjectPoolOptions(instrument.NewOptions()).(*objectPoolOptions)
+	require.Equal(t, 1, opts.size)
+	require.Equal(t, 0.1, opts.refillLowWatermark)
+	require.Equal(t, 0.5, opts.refillHighWatermark)
+}
+
+func TestBucketizedPoolConfiguration(t *testing.T) {
+	cfg := BucketizedPoolConfiguration{
+		Buckets: []BucketConfiguration{
+			{Count: 1, Capacity: 10},
+			{Count: 2, Capacity: 20},
+		},
+		WaterMark: WaterMarkConfiguration{
+			RefillLowWaterMark:  0.1,
+			RefillHighWaterMark: 0.5,
+		},
+	}
+	expectedBuckets := []Bucket{
+		{Count: 1, Capacity: 10},
+		{Count: 2, Capacity: 20},
+	}
+	require.Equal(t, expectedBuckets, cfg.NewBuckets())
+	opts := cfg.NewObjectPoolOptions(instrument.NewOptions()).(*objectPoolOptions)
+	require.Equal(t, 0.1, opts.refillLowWatermark)
+	require.Equal(t, 0.5, opts.refillHighWatermark)
+}

--- a/pool/options.go
+++ b/pool/options.go
@@ -23,8 +23,9 @@ package pool
 import "github.com/m3db/m3x/instrument"
 
 const (
-	defaultSize               = 4096
-	defaultRefillLowWatermark = 0
+	defaultSize                = 4096
+	defaultRefillLowWatermark  = 0.0
+	defaultRefillHighWatermark = 0.0
 )
 
 type objectPoolOptions struct {
@@ -40,6 +41,7 @@ func NewObjectPoolOptions() ObjectPoolOptions {
 	return &objectPoolOptions{
 		size:                defaultSize,
 		refillLowWatermark:  defaultRefillLowWatermark,
+		refillHighWatermark: defaultRefillHighWatermark,
 		instrumentOpts:      instrument.NewOptions(),
 		onPoolAccessErrorFn: func(err error) { panic(err) },
 	}

--- a/retry/config.go
+++ b/retry/config.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xretry
+
+import (
+	"time"
+
+	"github.com/uber-go/tally"
+)
+
+// Configuration configures options for retry attempts.
+type Configuration struct {
+	// Initial retry backoff.
+	InitialBackoff time.Duration `yaml:"initialBackoff"`
+
+	// Backoff factor for exponential backoff.
+	BackoffFactor float64 `yaml:"backoffFactor"`
+
+	// Maximum backoff time.
+	MaxBackoff time.Duration `yaml:"maxBackoff"`
+
+	// Maximum number of retry attempts.
+	MaxRetries int `yaml:"maxRetries"`
+
+	// Whether jittering is applied during retries.
+	Jitter bool `yaml:"jitter"`
+}
+
+// NewRetrier creates a new retrier based on the configuration.
+func (c Configuration) NewRetrier(scope tally.Scope) Retrier {
+	var (
+		initialBackoff = defaultInitialBackoff
+		backoffFactor  = defaultBackoffFactor
+		maxBackoff     = defaultMaxBackoff
+		maxRetries     = defaultMaxRetries
+	)
+	if c.InitialBackoff != 0 {
+		initialBackoff = c.InitialBackoff
+	}
+	if c.BackoffFactor != 0.0 {
+		backoffFactor = c.BackoffFactor
+	}
+	if c.MaxBackoff != 0 {
+		maxBackoff = c.MaxBackoff
+	}
+	if c.MaxRetries != 0 {
+		maxRetries = c.MaxRetries
+	}
+	retryOpts := NewOptions().
+		SetMetricsScope(scope).
+		SetInitialBackoff(initialBackoff).
+		SetBackoffFactor(backoffFactor).
+		SetMaxBackoff(maxBackoff).
+		SetMaxRetries(maxRetries).
+		SetJitter(c.Jitter)
+	return NewRetrier(retryOpts)
+}

--- a/retry/config_test.go
+++ b/retry/config_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xretry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+)
+
+func TestRetryConfig(t *testing.T) {
+	cfg := Configuration{
+		InitialBackoff: time.Second,
+		BackoffFactor:  2.0,
+		MaxBackoff:     time.Minute,
+		MaxRetries:     3,
+		Jitter:         true,
+	}
+	retrier := cfg.NewRetrier(tally.NoopScope).(*retrier)
+	require.Equal(t, time.Second, retrier.initialBackoff)
+	require.Equal(t, 2.0, retrier.backoffFactor)
+	require.Equal(t, time.Minute, retrier.maxBackoff)
+	require.Equal(t, 3, retrier.maxRetries)
+	require.True(t, retrier.jitter)
+}


### PR DESCRIPTION
cc @jeromefroe @martin-mao @cw9  @robskillington 

This PR adds metrics configurations to `instrument/` for reuse across repos.