### PR TITLE
Set gauges after pool is initialized

### DIFF
--- a/pool/object.go
+++ b/pool/object.go
@@ -100,6 +100,8 @@ func (p *objectPool) Init(alloc Allocator) {
 	for i := 0; i < cap(p.values); i++ {
 		p.values <- p.alloc()
 	}
+
+	p.setGauges()
 }
 
 func (p *objectPool) Get() interface{} {


### PR DESCRIPTION
cc @robskillington @cw9 @jeromefroe @prateek 

This PR sets the gauges after the object pool is initialized.