### PR TITLE
Add max positive skew and max negative skew to clock options

### DIFF
--- a/clock/options.go
+++ b/clock/options.go
@@ -25,7 +25,9 @@ import (
 )
 
 type options struct {
-	nowFn NowFn
+	nowFn           NowFn
+	maxPositiveSkew time.Duration
+	maxNegativeSkew time.Duration
 }
 
 // NewOptions creates new clock options
@@ -43,4 +45,24 @@ func (o *options) SetNowFn(value NowFn) Options {
 
 func (o *options) NowFn() NowFn {
 	return o.nowFn
+}
+
+func (o *options) SetMaxPositiveSkew(value time.Duration) Options {
+	opts := *o
+	opts.maxPositiveSkew = value
+	return &opts
+}
+
+func (o *options) MaxPositiveSkew() time.Duration {
+	return o.maxPositiveSkew
+}
+
+func (o *options) SetMaxNegativeSkew(value time.Duration) Options {
+	opts := *o
+	opts.maxNegativeSkew = value
+	return &opts
+}
+
+func (o *options) MaxNegativeSkew() time.Duration {
+	return o.maxNegativeSkew
 }

--- a/clock/types.go
+++ b/clock/types.go
@@ -34,6 +34,22 @@ type Options interface {
 
 	// NowFn returns the nowFn
 	NowFn() NowFn
+
+	// SetMaxPositiveSkew sets the maximum positive clock skew
+	// with regard to a reference clock.
+	SetMaxPositiveSkew(value time.Duration) Options
+
+	// MaxPositiveSkew returns the maximum positive clock skew
+	// with regard to a reference clock.
+	MaxPositiveSkew() time.Duration
+
+	// SetMaxNegativeSkew sets the maximum negative clock skew
+	// with regard to a reference clock.
+	SetMaxNegativeSkew(value time.Duration) Options
+
+	// MaxNegativeSkew returns the maximum negative clock skew
+	// with regard to a reference clock.
+	MaxNegativeSkew() time.Duration
 }
 
 // ConditionFn specifies a predicate to check


### PR DESCRIPTION
cc @cw9 @jeromefroe @robskillington @prateek 

This PR adds max positive clock skew and max negative clock skew as part of the clock options.