### PR TITLE
Add a utility function to determine the maximum unit for a duration

### DIFF
--- a/time/unit_test.go
+++ b/time/unit_test.go
@@ -38,6 +38,7 @@ func TestUnitValue(t *testing.T) {
 		{Microsecond, time.Microsecond},
 		{Nanosecond, time.Nanosecond},
 		{Minute, time.Minute},
+		{Hour, time.Hour},
 	}
 	for _, input := range inputs {
 		v, err := input.u.Value()
@@ -60,6 +61,7 @@ func TestUnitIsValid(t *testing.T) {
 		{Microsecond, true},
 		{Nanosecond, true},
 		{Minute, true},
+		{Hour, true},
 		{Unit(10), false},
 	}
 	for _, input := range inputs {
@@ -77,6 +79,7 @@ func TestUnitFromDuration(t *testing.T) {
 		{time.Microsecond, Microsecond},
 		{time.Nanosecond, Nanosecond},
 		{time.Minute, Minute},
+		{time.Hour, Hour},
 	}
 	for _, input := range inputs {
 		u, err := UnitFromDuration(input.d)
@@ -90,6 +93,34 @@ func TestUnitFromDurationError(t *testing.T) {
 	require.Equal(t, errConvertDurationToUnit, err)
 }
 
+func TestMaxUnitForDuration(t *testing.T) {
+	inputs := []struct {
+		d                time.Duration
+		expectedMultiple int64
+		expectedUnit     Unit
+	}{
+		{20 * time.Second, 20, Second},
+		{70 * time.Second, 70, Second},
+		{120 * time.Second, 2, Minute},
+		{30 * time.Nanosecond, 30, Nanosecond},
+		{999 * time.Millisecond, 999, Millisecond},
+		{60 * time.Microsecond, 60, Microsecond},
+		{10 * time.Minute, 10, Minute},
+		{20 * time.Hour, 20, Hour},
+	}
+	for _, input := range inputs {
+		m, u, err := MaxUnitForDuration(input.d)
+		require.NoError(t, err)
+		require.Equal(t, input.expectedMultiple, m)
+		require.Equal(t, input.expectedUnit, u)
+	}
+}
+
+func TestMaxUnitForDurationError(t *testing.T) {
+	_, _, err := MaxUnitForDuration(0)
+	require.Equal(t, errMaxUnitForDuration, err)
+}
+
 func TestDurationFromUnit(t *testing.T) {
 	inputs := []struct {
 		u        Unit
@@ -100,6 +131,7 @@ func TestDurationFromUnit(t *testing.T) {
 		{Microsecond, time.Microsecond},
 		{Nanosecond, time.Nanosecond},
 		{Minute, time.Minute},
+		{Hour, time.Hour},
 	}
 	for _, input := range inputs {
 		d, err := DurationFromUnit(input.u)
@@ -123,6 +155,7 @@ func TestUnitString(t *testing.T) {
 		{Microsecond, "us"},
 		{Nanosecond, "ns"},
 		{Minute, "m"},
+		{Hour, "h"},
 		{None, "unknown"},
 	}
 


### PR DESCRIPTION
cc @robskillington @cw9 @jeromefroe @prateek 

This PR adds a utility function to determine the maximum unit for a duration. This is needed when user provides a policy without specifying the resolution precision unit (e.g., "10s:1d"), in which case we use this function to determine what precision unit we should use (in this case 1s).