### PR TITLE
Add StartForeverLoop to support accepting connections in an infinite loop

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -90,6 +90,12 @@ func NewRetrier(opts Options) Retrier {
 	}
 }
 
+func (r *retrier) SetForeverRetry(forever bool) Retrier {
+	retrier := *r
+	retrier.forever = forever
+	return &retrier
+}
+
 func (r *retrier) Attempt(fn Fn) error {
 	return r.attempt(nil, fn)
 }

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -180,7 +180,7 @@ func TestRetryForever(t *testing.T) {
 		numAttempts int
 		totalSlept  time.Duration
 	)
-	r := NewRetrier(testOptions().SetForever(true)).(*retrier)
+	r := NewRetrier(testOptions().SetForever(true).SetMaxRetries(3)).(*retrier)
 	r.sleepFn = func(t time.Duration) {
 		totalSlept += t
 		numAttempts++
@@ -192,4 +192,10 @@ func TestRetryForever(t *testing.T) {
 	assert.Equal(t, ErrWhileConditionFalse, err)
 	assert.Equal(t, 10, numAttempts)
 	assert.Equal(t, time.Duration(1023*time.Second), totalSlept)
+
+	numAttempts = 0
+	r = r.SetForeverRetry(false).(*retrier)
+	err = r.Attempt(foreverFn)
+	assert.Equal(t, errForever, err)
+	assert.Equal(t, 3, numAttempts)
 }

--- a/retry/types.go
+++ b/retry/types.go
@@ -46,6 +46,10 @@ type ContinueFn func(attempt int) bool
 
 // Retrier is a executor that can retry attempts on executing methods
 type Retrier interface {
+	// SetForeverRetry sets the retry mode that determines whether attempts should
+	// be retried forever.
+	SetForeverRetry(forever bool) Retrier
+
 	// Attempt will attempt to perform a function with retries
 	Attempt(fn Fn) error
 

--- a/server/server.go
+++ b/server/server.go
@@ -121,7 +121,7 @@ func (s *server) ListenAndServe() error {
 }
 
 func (s *server) serve() error {
-	connCh, errCh := xnet.StartAcceptLoop(s.listener, s.opts.Retrier())
+	connCh, errCh := xnet.StartForeverAcceptLoop(s.listener, s.opts.Retrier())
 	for conn := range connCh {
 		conn := conn
 		if !s.addConnectionFn(conn) {


### PR DESCRIPTION
@robskillington @cw9

This PR adds `StartForeverLoop` to support accepting connections in an infinite loop.