### PR TITLE
[servers] Add Serve method to server interface

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -124,7 +124,7 @@ func (s *server) ListenAndServe() error {
 }
 
 func (s *server) Serve(l net.Listener) error {
-	s.address := l.Addr().String()
+	s.address = l.Addr().String()
 	s.listener = l
 	go s.serve()
 	return nil

--- a/server/server.go
+++ b/server/server.go
@@ -124,8 +124,7 @@ func (s *server) ListenAndServe() error {
 }
 
 func (s *server) Serve(l net.Listener) error {
-	addr := l.Addr()
-	s.address = addr.String()
+	s.address := l.Addr().String()
 	s.listener = l
 	go s.serve()
 	return nil

--- a/server/server.go
+++ b/server/server.go
@@ -39,6 +39,9 @@ type Server interface {
 	// handles data from those connections.
 	ListenAndServe() error
 
+	// Serve accepts and handles incoming connections on the listener l.
+	Serve(l net.Listener) error
+
 	// Close closes the server.
 	Close()
 }
@@ -116,6 +119,14 @@ func (s *server) ListenAndServe() error {
 		return err
 	}
 	s.listener = listener
+	go s.serve()
+	return nil
+}
+
+func (s *server) Serve(l net.Listener) error {
+	addr := l.Addr()
+	s.address = addr.String()
+	s.listener = l
 	go s.serve()
 	return nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -101,7 +101,7 @@ func TestServerListenAndClose(t *testing.T) {
 	require.Equal(t, expectedRes, h.res())
 }
 
-func TestServerServe(t *testing.T) {
+func TestServe(t *testing.T) {
 	s, _, _, _ := testServer(testListenAddress)
 
 	l, err := net.Listen("tcp", testListenAddress)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -101,6 +101,18 @@ func TestServerListenAndClose(t *testing.T) {
 	require.Equal(t, expectedRes, h.res())
 }
 
+func TestServerServe(t *testing.T) {
+	s, _, _, _ := testServer(testListenAddress)
+
+	l, err := net.Listen("tcp", testListenAddress)
+	require.NoError(t, err)
+
+	err = s.Serve(l)
+	require.NoError(t, err)
+
+	s.Close()
+}
+
 type mockHandler struct {
 	sync.Mutex
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -109,6 +109,8 @@ func TestServe(t *testing.T) {
 
 	err = s.Serve(l)
 	require.NoError(t, err)
+	require.Equal(t, l, s.listener)
+	require.Equal(t, l.Addr().String(), s.address)
 
 	s.Close()
 }


### PR DESCRIPTION
@xichen2020 @cw9 

This PR adds a `Serve(l net.Listener)` method to the `Server` interface so that we can explicitly pass a listener to a `Server`. This will be helpful in testing when we don't know in advance what port we want to listen on.