### PR TITLE
Add ListenAndServeForever to m3x server

### DIFF
--- a/net/server.go
+++ b/net/server.go
@@ -30,11 +30,12 @@ import (
 // StartAcceptLoop starts an accept loop for the given listener,
 // returning accepted connections via a channel while handling
 // temporary network errors. Fatal errors are returned via the
-// error channel with the listener closed on return
-func StartAcceptLoop(l net.Listener, retrier xretry.Retrier) (<-chan net.Conn, <-chan error) {
+// error channel with the listener closed on return.
+func StartAcceptLoop(l net.Listener, rOpts xretry.Options) (<-chan net.Conn, <-chan error) {
 	var (
-		connCh = make(chan net.Conn)
-		errCh  = make(chan error)
+		connCh  = make(chan net.Conn)
+		errCh   = make(chan error)
+		retrier = xretry.NewRetrier(rOpts)
 	)
 
 	go func() {
@@ -65,4 +66,13 @@ func StartAcceptLoop(l net.Listener, retrier xretry.Retrier) (<-chan net.Conn, <
 	}()
 
 	return connCh, errCh
+}
+
+// StartForeverAcceptLoop starts an accept loop for the
+// given listener that retries forever, returning
+// accepted connections via a channel while handling
+// temporary network errors. Fatal errors are returned via the
+// error channel with the listener closed on return.
+func StartForeverAcceptLoop(l net.Listener, rOpts xretry.Options) (<-chan net.Conn, <-chan error) {
+	return StartAcceptLoop(l, rOpts.SetForever(true))
 }

--- a/net/server_test.go
+++ b/net/server_test.go
@@ -40,12 +40,11 @@ func TestStartAcceptLoop(t *testing.T) {
 		wgClient       sync.WaitGroup
 		wgServer       sync.WaitGroup
 		numConnections = 10
-		retrier        = xretry.NewRetrier(xretry.NewOptions())
 	)
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.Nil(t, err)
-	connCh, errCh := StartAcceptLoop(l, retrier)
+	connCh, errCh := StartForeverAcceptLoop(l, xretry.NewOptions())
 
 	wgServer.Add(1)
 	go func() {

--- a/server/options.go
+++ b/server/options.go
@@ -33,23 +33,23 @@ type Options interface {
 	// InstrumentOptions returns the instrument options
 	InstrumentOptions() instrument.Options
 
-	// SetRetrier sets the retrier for accepting connections
-	SetRetrier(value xretry.Retrier) Options
+	// SetRetryOptions sets the retry options
+	SetRetryOptions(value xretry.Options) Options
 
-	// Retrier returns the retrier for accepting connections
-	Retrier() xretry.Retrier
+	// RetryOptions returns the retry options
+	RetryOptions() xretry.Options
 }
 
 type options struct {
 	instrumentOpts instrument.Options
-	retrier        xretry.Retrier
+	retryOpts      xretry.Options
 }
 
 // NewOptions creates a new set of server options
 func NewOptions() Options {
 	return &options{
 		instrumentOpts: instrument.NewOptions(),
-		retrier:        xretry.NewRetrier(xretry.NewOptions()),
+		retryOpts:      xretry.NewOptions(),
 	}
 }
 
@@ -63,12 +63,12 @@ func (o *options) InstrumentOptions() instrument.Options {
 	return o.instrumentOpts
 }
 
-func (o *options) SetRetrier(value xretry.Retrier) Options {
+func (o *options) SetRetryOptions(value xretry.Options) Options {
 	opts := *o
-	opts.retrier = value
+	opts.retryOpts = value
 	return &opts
 }
 
-func (o *options) Retrier() xretry.Retrier {
-	return o.retrier
+func (o *options) RetryOptions() xretry.Options {
+	return o.retryOpts
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -43,7 +43,7 @@ func testServer(addr string) (*server, *mockHandler, *int32, *int32) {
 		numRemoved int32
 	)
 
-	opts := NewOptions().SetRetrier(xretry.NewRetrier(xretry.NewOptions().SetMaxRetries(2)))
+	opts := NewOptions().SetRetryOptions(xretry.NewOptions().SetMaxRetries(2))
 	opts = opts.SetInstrumentOptions(opts.InstrumentOptions().SetReportInterval(time.Second))
 
 	h := newMockHandler()


### PR DESCRIPTION
Add this API as per discussion, although I feel we should just change ListenAndServe() and Serve() to do the Forever thing under the hood rather than adding this new API, because the user of the server interface has no way of knowing if the server has gone out of retries.

@xichen2020 @robskillington @jeromefroe @prateek 