### PR TITLE
Optionally support keepalives for tcp connections

### DIFF
--- a/server/options.go
+++ b/server/options.go
@@ -25,6 +25,10 @@ import (
 	"github.com/m3db/m3x/retry"
 )
 
+const (
+	defaultTCPConnectionKeepAlive = true
+)
+
 // Options provide a set of server options
 type Options interface {
 	// SetInstrumentOptions sets the instrument options
@@ -38,18 +42,26 @@ type Options interface {
 
 	// RetryOptions returns the retry options
 	RetryOptions() xretry.Options
+
+	// SetTCPConnectionKeepAlive sets the keep alive state for tcp connections.
+	SetTCPConnectionKeepAlive(value bool) Options
+
+	// TCPConnectionKeepAlive returns the keep alive state for tcp connections.
+	TCPConnectionKeepAlive() bool
 }
 
 type options struct {
-	instrumentOpts instrument.Options
-	retryOpts      xretry.Options
+	instrumentOpts         instrument.Options
+	retryOpts              xretry.Options
+	tcpConnectionKeepAlive bool
 }
 
 // NewOptions creates a new set of server options
 func NewOptions() Options {
 	return &options{
-		instrumentOpts: instrument.NewOptions(),
-		retryOpts:      xretry.NewOptions(),
+		instrumentOpts:         instrument.NewOptions(),
+		retryOpts:              xretry.NewOptions(),
+		tcpConnectionKeepAlive: defaultTCPConnectionKeepAlive,
 	}
 }
 
@@ -71,4 +83,14 @@ func (o *options) SetRetryOptions(value xretry.Options) Options {
 
 func (o *options) RetryOptions() xretry.Options {
 	return o.retryOpts
+}
+
+func (o *options) SetTCPConnectionKeepAlive(value bool) Options {
+	opts := *o
+	opts.tcpConnectionKeepAlive = value
+	return &opts
+}
+
+func (o *options) TCPConnectionKeepAlive() bool {
+	return o.tcpConnectionKeepAlive
 }

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/net"
+	"github.com/m3db/m3x/retry"
 
 	"github.com/uber-go/tally"
 )
@@ -73,10 +74,12 @@ type removeConnectionFn func(conn net.Conn)
 type server struct {
 	sync.Mutex
 
-	address  string
-	listener net.Listener
-	opts     Options
-	log      xlog.Logger
+	address                string
+	listener               net.Listener
+	opts                   Options
+	log                    xlog.Logger
+	retryOpts              xretry.Options
+	tcpConnectionKeepAlive bool
 
 	closed     bool
 	closedChan chan struct{}
@@ -96,12 +99,14 @@ func NewServer(address string, handler Handler, opts Options) Server {
 	scope := instrumentOpts.MetricsScope()
 
 	s := &server{
-		address:    address,
-		opts:       opts,
-		log:        instrumentOpts.Logger(),
-		closedChan: make(chan struct{}),
-		metrics:    newServerMetrics(scope),
-		handler:    handler,
+		address:                address,
+		opts:                   opts,
+		log:                    instrumentOpts.Logger(),
+		retryOpts:              opts.RetryOptions(),
+		tcpConnectionKeepAlive: opts.TCPConnectionKeepAlive(),
+		closedChan:             make(chan struct{}),
+		metrics:                newServerMetrics(scope),
+		handler:                handler,
 	}
 
 	// Set up the connection functions.
@@ -131,9 +136,12 @@ func (s *server) Serve(l net.Listener) error {
 }
 
 func (s *server) serve() error {
-	connCh, errCh := xnet.StartForeverAcceptLoop(s.listener, s.opts.RetryOptions())
+	connCh, errCh := xnet.StartForeverAcceptLoop(s.listener, s.retryOpts)
 	for conn := range connCh {
 		conn := conn
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			tcpConn.SetKeepAlive(s.tcpConnectionKeepAlive)
+		}
 		if !s.addConnectionFn(conn) {
 			conn.Close()
 		} else {

--- a/server/server.go
+++ b/server/server.go
@@ -76,9 +76,9 @@ type server struct {
 
 	address                string
 	listener               net.Listener
-	opts                   Options
 	log                    xlog.Logger
 	retryOpts              xretry.Options
+	reportInterval         time.Duration
 	tcpConnectionKeepAlive bool
 
 	closed     bool
@@ -100,9 +100,9 @@ func NewServer(address string, handler Handler, opts Options) Server {
 
 	s := &server{
 		address:                address,
-		opts:                   opts,
 		log:                    instrumentOpts.Logger(),
 		retryOpts:              opts.RetryOptions(),
+		reportInterval:         instrumentOpts.ReportInterval(),
 		tcpConnectionKeepAlive: opts.TCPConnectionKeepAlive(),
 		closedChan:             make(chan struct{}),
 		metrics:                newServerMetrics(scope),
@@ -217,7 +217,7 @@ func (s *server) removeConnection(conn net.Conn) {
 }
 
 func (s *server) reportMetrics() {
-	t := time.NewTicker(s.opts.InstrumentOptions().ReportInterval())
+	t := time.NewTicker(s.reportInterval)
 
 	for {
 		select {


### PR DESCRIPTION
cc @cw9 

This PR adds support to optionally set keepAlives for TCP connections.