### PR TITLE
Add Equal() to xtime.Range

### DIFF
--- a/time/range.go
+++ b/time/range.go
@@ -36,6 +36,11 @@ func (r Range) IsEmpty() bool {
 	return r.Start == r.End
 }
 
+// Equal returns whether two time ranges are equal.
+func (r Range) Equal(other Range) bool {
+	return r.Start.Equal(other.Start) && r.End.Equal(other.End)
+}
+
 // Before determines whether r is before other.
 func (r Range) Before(other Range) bool {
 	return !r.End.After(other.Start)

--- a/time/range_test.go
+++ b/time/range_test.go
@@ -104,6 +104,38 @@ func TestRangeIsEmpty(t *testing.T) {
 	require.False(t, r.IsEmpty())
 }
 
+func TestEqual(t *testing.T) {
+	inputs := []struct {
+		a, b     Range
+		expected bool
+	}{
+		{
+			a:        Range{Start: time.Unix(12, 0), End: time.Unix(34, 0)},
+			b:        Range{Start: time.Unix(12, 0), End: time.Unix(34, 0)},
+			expected: true,
+		},
+		{
+			a:        Range{Start: time.Unix(12, 0), End: time.Unix(34, 0)},
+			b:        Range{Start: time.Unix(12, 0).UTC(), End: time.Unix(34, 0).UTC()},
+			expected: true,
+		},
+		{
+			a:        Range{Start: time.Unix(12, 0), End: time.Unix(34, 0)},
+			b:        Range{Start: time.Unix(13, 0), End: time.Unix(34, 0)},
+			expected: false,
+		},
+		{
+			a:        Range{Start: time.Unix(12, 0), End: time.Unix(34, 0)},
+			b:        Range{Start: time.Unix(12, 0), End: time.Unix(36, 0)},
+			expected: false,
+		},
+	}
+	for _, input := range inputs {
+		require.Equal(t, input.expected, input.a.Equal(input.b))
+		require.Equal(t, input.expected, input.b.Equal(input.a))
+	}
+}
+
 func TestRangeBefore(t *testing.T) {
 	input := testInput()
 	expected := []bool{


### PR DESCRIPTION
cc @cw9 @robskillington 

This PR adds `Equal()` to `xtime.Range` to properly compare two time ranges.