### PR TITLE
[glide] Update tally dependency to be compatible with any 3.x.x version

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4214e6905b6a7d851f01b86dd6ea69691a46c34539e77723224acf026fa9b492
-updated: 2017-04-29T16:49:27.216859815-04:00
+hash: a92292a1d3f0186f2b2d879bd1ec5f09c064dd0879744a4dda11cebf7441fc6a
+updated: 2017-08-18T14:43:48.072806974-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -34,7 +34,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
-  version: 4b9d9de43ffcb0b7efe67dab2a92c2d58dbf16ab
+  version: 2605c407d7d219644d03a3680ad7df4779017782
   subpackages:
   - m3
   - m3/customtransports

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
   - assert
   - require
 - package: github.com/uber-go/tally
-  version: 3.0.0
+  version: ^3.0.0 # ie >= 3.0.0, < 4.0.0
 - package: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - package: gopkg.in/yaml.v2


### PR DESCRIPTION
To take advantage of the new sanitization features of `tally` we need to use the newest release which is `3.1.0`. However, we pin the version of `tally` to `3.0.0` in many of the repos under `m3db` which means that any package which depends on them cannot upgrade. This PR, therefore, is to change the version of `tally` from `3.0.0` to `^3.0.0`, so we can use any `3.x.x` release.

cc @xichen2020 @prateek 