### PR TITLE
[time] Add a Duration method to Range and a Count method to Unit

### DIFF
--- a/time/range.go
+++ b/time/range.go
@@ -61,6 +61,11 @@ func (r Range) Overlaps(other Range) bool {
 	return r.End.After(other.Start) && r.Start.Before(other.End)
 }
 
+// Duration returns the duration of the range.
+func (r Range) Duration() time.Duration {
+	return r.End.Sub(r.Start)
+}
+
 // Intersect calculates the intersection of the receiver range against the
 // provided argument range iff there is an overlap between the two. It also
 // returns a bool indicating if there was a valid intersection.

--- a/time/range_test.go
+++ b/time/range_test.go
@@ -183,6 +183,25 @@ func TestRangeOverlaps(t *testing.T) {
 	}
 }
 
+func TestRangeDuration(t *testing.T) {
+	inputs := []struct {
+		r        Range
+		expected time.Duration
+	}{
+		{
+			r:        Range{Start: time.Unix(12, 0), End: time.Unix(34, 0)},
+			expected: 22 * time.Second,
+		},
+		{
+			r:        Range{Start: time.Unix(8, 0), End: time.Unix(8, 0)},
+			expected: 0,
+		},
+	}
+	for _, input := range inputs {
+		require.Equal(t, input.expected, input.r.Duration())
+	}
+}
+
 func TestRangeIntersect(t *testing.T) {
 	input := testInput()
 	for i := 0; i < len(input); i++ {

--- a/time/unit.go
+++ b/time/unit.go
@@ -57,11 +57,17 @@ func (tu Unit) Value() (time.Duration, error) {
 }
 
 // Count returns the number of units contained within the duration.
-func (tu Unit) Count(d time.Duration) (int, error) {
-	if dur, found := unitsToDuration[tu]; found {
-		return int(d / dur), nil
+func (tu Unit) Count(d time.Duration) int {
+	if d < 0 {
+		return -1
 	}
-	return 0, errUnrecognizedTimeUnit
+
+	if dur, found := unitsToDuration[tu]; found {
+		return int(d / dur)
+	}
+
+	// Invalid unit.
+	return -1
 }
 
 // IsValid returns whether the given time unit is valid / supported.

--- a/time/unit.go
+++ b/time/unit.go
@@ -43,6 +43,7 @@ var (
 	errConvertDurationToUnit = errors.New("unable to convert from duration to time unit")
 	errConvertUnitToDuration = errors.New("unable to convert from time unit to duration")
 	errMaxUnitForDuration    = errors.New("unable to determine the maximum unit for duration")
+	errNegativeDuraton       = errors.New("duration cannot be negative")
 )
 
 // Unit represents a time unit.
@@ -57,17 +58,28 @@ func (tu Unit) Value() (time.Duration, error) {
 }
 
 // Count returns the number of units contained within the duration.
-func (tu Unit) Count(d time.Duration) int {
+func (tu Unit) Count(d time.Duration) (int, error) {
 	if d < 0 {
-		return -1
+		return 0, errNegativeDuraton
 	}
 
 	if dur, found := unitsToDuration[tu]; found {
-		return int(d / dur)
+		return int(d / dur), nil
 	}
 
 	// Invalid unit.
-	return -1
+	return 0, errUnrecognizedTimeUnit
+}
+
+// MustCount is like Count but panics if d is negative or if tu is not
+// a valid Unit.
+func (tu Unit) MustCount(d time.Duration) int {
+	c, err := tu.Count(d)
+	if err != nil {
+		panic(err)
+	}
+
+	return c
 }
 
 // IsValid returns whether the given time unit is valid / supported.

--- a/time/unit.go
+++ b/time/unit.go
@@ -56,6 +56,14 @@ func (tu Unit) Value() (time.Duration, error) {
 	return 0, errUnrecognizedTimeUnit
 }
 
+// Count returns the number of units contained within the duration.
+func (tu Unit) Count(d time.Duration) (int, error) {
+	if dur, found := unitsToDuration[tu]; found {
+		return int(d / dur), nil
+	}
+	return 0, errUnrecognizedTimeUnit
+}
+
 // IsValid returns whether the given time unit is valid / supported.
 func (tu Unit) IsValid() bool {
 	_, valid := unitsToDuration[tu]

--- a/time/unit_test.go
+++ b/time/unit_test.go
@@ -63,14 +63,21 @@ func TestUnitCount(t *testing.T) {
 		{Nanosecond, time.Microsecond, 1000},
 	}
 	for _, input := range inputs {
-		v, err := input.u.Count(input.d)
-		require.NoError(t, err)
-		require.Equal(t, input.expected, v)
+		c := input.u.Count(input.d)
+		require.Equal(t, input.expected, c)
 	}
 
 	invalidUnit := Unit(10)
-	_, err := invalidUnit.Count(time.Second)
-	require.Equal(t, errUnrecognizedTimeUnit, err)
+	c := invalidUnit.Count(time.Second)
+	require.Equal(t, -1, c)
+
+	var (
+		u               = Second
+		invalidDuration = -1 * time.Second
+	)
+	c = u.Count(invalidDuration)
+	require.Equal(t, -1, c)
+
 }
 
 func TestUnitIsValid(t *testing.T) {

--- a/time/unit_test.go
+++ b/time/unit_test.go
@@ -63,21 +63,51 @@ func TestUnitCount(t *testing.T) {
 		{Nanosecond, time.Microsecond, 1000},
 	}
 	for _, input := range inputs {
-		c := input.u.Count(input.d)
+		c, err := input.u.Count(input.d)
+		require.NoError(t, err)
 		require.Equal(t, input.expected, c)
 	}
 
 	invalidUnit := Unit(10)
-	c := invalidUnit.Count(time.Second)
-	require.Equal(t, -1, c)
+	_, err := invalidUnit.Count(time.Second)
+	require.Error(t, err)
 
 	var (
 		u               = Second
 		invalidDuration = -1 * time.Second
 	)
-	c = u.Count(invalidDuration)
-	require.Equal(t, -1, c)
+	_, err = u.Count(invalidDuration)
+	require.Error(t, err)
+}
 
+func TestUnitMustCount(t *testing.T) {
+	inputs := []struct {
+		u        Unit
+		d        time.Duration
+		expected int
+	}{
+		{Second, time.Second, 1},
+		{Millisecond, 10 * time.Millisecond, 10},
+		{Microsecond, time.Nanosecond, 0},
+		{Nanosecond, time.Microsecond, 1000},
+	}
+	for _, input := range inputs {
+		c := input.u.MustCount(input.d)
+		require.Equal(t, input.expected, c)
+	}
+
+	invalidUnit := Unit(10)
+	require.Panics(t, func() {
+		invalidUnit.MustCount(time.Second)
+	})
+
+	var (
+		u               = Second
+		invalidDuration = -1 * time.Second
+	)
+	require.Panics(t, func() {
+		u.MustCount(invalidDuration)
+	})
 }
 
 func TestUnitIsValid(t *testing.T) {

--- a/time/unit_test.go
+++ b/time/unit_test.go
@@ -51,6 +51,28 @@ func TestUnitValue(t *testing.T) {
 	require.Equal(t, errUnrecognizedTimeUnit, err)
 }
 
+func TestUnitCount(t *testing.T) {
+	inputs := []struct {
+		u        Unit
+		d        time.Duration
+		expected int
+	}{
+		{Second, time.Second, 1},
+		{Millisecond, 10 * time.Millisecond, 10},
+		{Microsecond, time.Nanosecond, 0},
+		{Nanosecond, time.Microsecond, 1000},
+	}
+	for _, input := range inputs {
+		v, err := input.u.Count(input.d)
+		require.NoError(t, err)
+		require.Equal(t, input.expected, v)
+	}
+
+	invalidUnit := Unit(10)
+	_, err := invalidUnit.Count(time.Second)
+	require.Equal(t, errUnrecognizedTimeUnit, err)
+}
+
 func TestUnitIsValid(t *testing.T) {
 	inputs := []struct {
 		u        Unit


### PR DESCRIPTION
This PR adds a `Duration` method to the `Range` struct in the `time` package which returns the duration of the range a `Count` method to `Unit` which returns the number of units contained within a duration.

cc @xichen2020 