### PR TITLE
[errors] Add functions to Wrap errors and preserve type

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -90,8 +90,8 @@ func Wrap(err error, msg string) error {
 	return NewRenamedError(err, renamed)
 }
 
-// Wrapf formats according to a format specifier and returns a new error
-// with that string as its value while preserving the type of the error.
+// Wrapf formats according to a format specifier and uses that string to
+// wrap an error while still preserving the type of the error.
 func Wrapf(err error, format string, args ...interface{}) error {
 	msg := fmt.Sprintf(format, args...)
 	return Wrap(err, msg)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -20,7 +20,11 @@
 
 package xerrors
 
-import "bytes"
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
 
 // FirstError will return the first non nil error
 func FirstError(errs ...error) error {
@@ -78,6 +82,19 @@ func (e renamedError) InnerError() error {
 
 type invalidParamsError struct {
 	containedError
+}
+
+// Wrap wraps an error with a message but preserves the type of the error.
+func Wrap(err error, msg string) error {
+	renamed := errors.New(msg + ": " + err.Error())
+	return NewRenamedError(err, renamed)
+}
+
+// Wrapf formats according to a format specifier and returns a new error
+// with that string as its value while preserving the type of the error.
+func Wrapf(err error, format string, args ...interface{}) error {
+	msg := fmt.Sprintf(format, args...)
+	return Wrap(err, msg)
 }
 
 // NewInvalidParamsError creates a new invalid params error

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -29,6 +29,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWrap(t *testing.T) {
+	inner := errors.New("detailed error message")
+	err := NewInvalidParamsError(inner)
+	wrappedErr := Wrap(err, "context about params error")
+	assert.Error(t, wrappedErr)
+	assert.Equal(t, "context about params error: detailed error message", wrappedErr.Error())
+	assert.True(t, IsInvalidParams(wrappedErr))
+
+	err = NewRetryableError(inner)
+	wrappedErr = Wrap(err, "context about retryable error")
+	assert.Error(t, wrappedErr)
+	assert.Equal(t, "context about retryable error: detailed error message", wrappedErr.Error())
+	assert.True(t, IsRetryableError(wrappedErr))
+
+	err = NewNonRetryableError(inner)
+	wrappedErr = Wrap(err, "context about nonretryable error")
+	assert.Error(t, wrappedErr)
+	assert.Equal(t, "context about nonretryable error: detailed error message", wrappedErr.Error())
+	assert.True(t, IsNonRetryableError(wrappedErr))
+}
+
+func TestWrapf(t *testing.T) {
+	inner := errors.New("detailed error message")
+	err := NewInvalidParamsError(inner)
+	wrappedErr := Wrapf(err, "context about %s error", "params")
+	assert.Error(t, wrappedErr)
+	assert.Equal(t, "context about params error: detailed error message", wrappedErr.Error())
+	assert.True(t, IsInvalidParams(wrappedErr))
+
+	err = NewRetryableError(inner)
+	wrappedErr = Wrapf(err, "context about %s error", "retryable")
+	assert.Error(t, wrappedErr)
+	assert.Equal(t, "context about retryable error: detailed error message", wrappedErr.Error())
+	assert.True(t, IsRetryableError(wrappedErr))
+
+	err = NewNonRetryableError(inner)
+	wrappedErr = Wrapf(err, "context about %s error", "nonretryable")
+	assert.Error(t, wrappedErr)
+	assert.Equal(t, "context about nonretryable error: detailed error message", wrappedErr.Error())
+	assert.True(t, IsNonRetryableError(wrappedErr))
+}
+
 func TestMultiErrorNoError(t *testing.T) {
 	err := NewMultiError()
 	require.Nil(t, err.FinalError())


### PR DESCRIPTION
This PR adds two functions, `Wrap` and `Wrapf`, that allow one to wrap an error with additional context while still preserving the underlying type of the error. These functions address the problem that one cannot use `fmt.Errorf` to wrap errors because that loses the type information of the error which is being wrapped. One can accomplish the same thing currently with `NewRenamedError` and `Wrap` and `Wrapf` aim to make such tasks easier to perform.