### PR TITLE
[refactor] Use consistent naming approach for packages

### DIFF
--- a/close/close.go
+++ b/close/close.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xclose provides utilities for closing resources.
-package xclose
+// Package close provides utilities for closing resources.
+package close
 
 import (
 	"errors"

--- a/close/close_test.go
+++ b/close/close_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xclose
+package close
 
 import (
 	"errors"

--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xconfig provides utilities for loading configuration files.
-package xconfig
+// Package config provides utilities for loading configuration files.
+package config
 
 import (
 	"errors"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xconfig
+package config
 
 import (
 	"io/ioutil"

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xconfig_test
+package config_test
 
 import (
 	"fmt"
@@ -27,13 +27,13 @@ import (
 	"github.com/m3db/m3x/config"
 )
 
-type config struct {
+type configuration struct {
 	ListenAddress string `yaml:"listenAddress" validate:"nonzero"`
 }
 
 func ExampleLoadFile() {
-	var cfg config
-	if err := xconfig.LoadFile(&cfg, "testdata/conf.yaml"); err != nil {
+	var cfg configuration
+	if err := config.LoadFile(&cfg, "testdata/conf.yaml"); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Printf("listenAddress: %s\n", cfg.ListenAddress)

--- a/debug/mutex.go
+++ b/debug/mutex.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xdebug provides utilities for debugging.
-package xdebug
+// Package debug provides utilities for debugging.
+package debug
 
 import (
 	"fmt"
@@ -51,7 +51,7 @@ func SetRWMutexStackBufferLength(value int) {
 // RWMutex is a debug wrapper for sync.RWMutex
 type RWMutex struct {
 	Name   string
-	Log    xlog.Logger
+	Log    log.Logger
 	Writer io.Writer
 
 	mutex          sync.RWMutex
@@ -123,7 +123,7 @@ func (m *RWMutex) Report() {
 }
 
 // ReportEvery will report the state of the RWMutex at a regular interval
-func (m *RWMutex) ReportEvery(interval time.Duration) xclose.SimpleCloser {
+func (m *RWMutex) ReportEvery(interval time.Duration) close.SimpleCloser {
 	ticker := time.NewTicker(interval)
 	go func() {
 		for range ticker.C {

--- a/debug/mutex_test.go
+++ b/debug/mutex_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xdebug
+package debug
 
 import (
 	"strings"

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xerrors provides utilities for working with different types errors.
-package xerrors
+// Package errors provides utilities for working with different types errors.
+package errors
 
 import (
 	"bytes"

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xerrors
+package errors
 
 import (
 	"errors"

--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xerrors_test
+package errors_test
 
 import (
 	"fmt"
@@ -28,7 +28,7 @@ import (
 )
 
 func ExampleMultiError() {
-	mutliErr := xerrors.NewMultiError()
+	mutliErr := errors.NewMultiError()
 
 	for i := 0; i < 3; i++ {
 		// Perform some work which may fail.

--- a/id/hash.go
+++ b/id/hash.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xid provides utilities for generating ID's from hash functions.
-package xid
+// Package id provides utilities for generating ID's from hash functions.
+package id
 
 import "crypto/md5"
 

--- a/id/hash_test.go
+++ b/id/hash_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xid
+package id
 
 import (
 	"crypto/md5"

--- a/instrument/options.go
+++ b/instrument/options.go
@@ -41,7 +41,7 @@ type options struct {
 
 // NewOptions creates new instrument options.
 func NewOptions() Options {
-	logger := log.NewLevelLogger(log.SimpleLogger, log.LogLevelInfo)
+	logger := log.NewLevelLogger(log.SimpleLogger, log.LevelInfo)
 	return &options{
 		logger:         logger,
 		scope:          tally.NoopScope,

--- a/instrument/options.go
+++ b/instrument/options.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/m3db/m3x/log"
-
 	"github.com/uber-go/tally"
 )
 
@@ -34,7 +33,7 @@ const (
 )
 
 type options struct {
-	logger         xlog.Logger
+	logger         log.Logger
 	scope          tally.Scope
 	samplingRate   float64
 	reportInterval time.Duration
@@ -42,7 +41,7 @@ type options struct {
 
 // NewOptions creates new instrument options.
 func NewOptions() Options {
-	logger := xlog.NewLevelLogger(xlog.SimpleLogger, xlog.LogLevelInfo)
+	logger := log.NewLevelLogger(log.SimpleLogger, log.LogLevelInfo)
 	return &options{
 		logger:         logger,
 		scope:          tally.NoopScope,
@@ -51,13 +50,13 @@ func NewOptions() Options {
 	}
 }
 
-func (o *options) SetLogger(value xlog.Logger) Options {
+func (o *options) SetLogger(value log.Logger) Options {
 	opts := *o
 	opts.logger = value
 	return &opts
 }
 
-func (o *options) Logger() xlog.Logger {
+func (o *options) Logger() log.Logger {
 	return o.logger
 }
 

--- a/instrument/types.go
+++ b/instrument/types.go
@@ -47,10 +47,10 @@ type BuildReporter interface {
 // Options represents the options for instrumentation.
 type Options interface {
 	// SetLogger sets the logger.
-	SetLogger(value xlog.Logger) Options
+	SetLogger(value log.Logger) Options
 
 	// Logger returns the logger.
-	Logger() xlog.Logger
+	Logger() log.Logger
 
 	// SetMetricsScope sets the metrics scope.
 	SetMetricsScope(value tally.Scope) Options

--- a/log/config.go
+++ b/log/config.go
@@ -48,7 +48,7 @@ func (cfg Configuration) BuildLogger() (Logger, error) {
 	logger := NewLogger(writer)
 
 	if len(cfg.Level) != 0 {
-		level, err := ParseLogLevel(cfg.Level)
+		level, err := ParseLevel(cfg.Level)
 		if err != nil {
 			return nil, err
 		}
@@ -57,9 +57,9 @@ func (cfg Configuration) BuildLogger() (Logger, error) {
 	}
 
 	if len(cfg.Fields) != 0 {
-		var fields []LogField
+		var fields []Field
 		for k, v := range cfg.Fields {
-			fields = append(fields, NewLogField(k, v))
+			fields = append(fields, NewField(k, v))
 		}
 		logger = logger.WithFields(fields...)
 	}

--- a/log/config.go
+++ b/log/config.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xlog
+package log
 
 import (
 	"io"

--- a/log/config_test.go
+++ b/log/config_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xlog
+package log
 
 import (
 	"io/ioutil"

--- a/log/logger.go
+++ b/log/logger.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xlog implements a logging package.
+// Package log implements a logging package.
 package log
 
 import (
@@ -32,7 +32,7 @@ import (
 // Logger provides an abstract interface for logging.
 type Logger interface {
 	// Enabled returns whether the given level is enabled.
-	Enabled(level LogLevel) bool
+	Enabled(level Level) bool
 
 	// Fatalf logs a message, then exits with os.Exit(1).
 	Fatalf(msg string, args ...interface{})
@@ -65,71 +65,71 @@ type Logger interface {
 	Debug(msg string)
 
 	// Fields returns the fields that this logger contains.
-	Fields() LogFields
+	Fields() LoggerFields
 
 	// WithFields returns a logger with the current logger's fields and fields.
-	WithFields(fields ...LogField) Logger
+	WithFields(fields ...Field) Logger
 }
 
-// LogField is a single field of additional information passed to the logger.
-type LogField interface {
+// Field is a single field of additional information passed to the logger.
+type Field interface {
 	Key() string
 	Value() interface{}
 }
 
-// NewLogField creates a new log field.
-func NewLogField(key string, value interface{}) LogField {
-	return &logField{key, value}
+// NewField creates a new log field.
+func NewField(key string, value interface{}) Field {
+	return &field{key, value}
 }
 
-// NewLogErrField wraps an error string as a LogField named "error".
-func NewLogErrField(err error) LogField {
-	return NewLogField("error", err.Error())
+// NewErrField wraps an error string as a Field named "error".
+func NewErrField(err error) Field {
+	return NewField("error", err.Error())
 }
 
-type logField struct {
+type field struct {
 	key   string
 	value interface{}
 }
 
-func (f *logField) Key() string {
+func (f *field) Key() string {
 	return f.key
 }
 
-func (f *logField) Value() interface{} {
+func (f *field) Value() interface{} {
 	return f.value
 }
 
-func (f *logField) String() string {
+func (f *field) String() string {
 	return fmt.Sprintf("%v", *f)
 }
 
-// LogFields is a list of LogFields used to pass additional information to the logger.
-type LogFields interface {
+// LoggerFields is a list of Fields used to pass additional information to the logger.
+type LoggerFields interface {
 	// Len returns the length
 	Len() int
 
 	// ValueAt returns a value for an index.
-	ValueAt(i int) LogField
+	ValueAt(i int) Field
 }
 
-// Fields is a list of log fields that implements the LogFields interface.
-type Fields []LogField
+// Fields is a list of log fields that implements the LoggerFields interface.
+type Fields []Field
 
 // Len returns the length.
 func (f Fields) Len() int { return len(f) }
 
 // ValueAt returns a value for an index.
-func (f Fields) ValueAt(i int) LogField { return f[i] }
+func (f Fields) ValueAt(i int) Field { return f[i] }
 
 // NullLogger is a logger that emits nowhere.
 var NullLogger Logger = nullLogger{}
 
 type nullLogger struct {
-	fields LogFields
+	fields Fields
 }
 
-func (nullLogger) Enabled(_ LogLevel) bool                { return false }
+func (nullLogger) Enabled(_ Level) bool                   { return false }
 func (nullLogger) Fatalf(msg string, args ...interface{}) {}
 func (nullLogger) Fatal(msg string)                       { os.Exit(1) }
 func (nullLogger) Errorf(msg string, args ...interface{}) {}
@@ -140,9 +140,9 @@ func (nullLogger) Infof(msg string, args ...interface{})  {}
 func (nullLogger) Info(msg string)                        {}
 func (nullLogger) Debugf(msg string, args ...interface{}) {}
 func (nullLogger) Debug(msg string)                       {}
-func (l nullLogger) Fields() LogFields                    { return l.fields }
+func (l nullLogger) Fields() LoggerFields                 { return l.fields }
 
-func (l nullLogger) WithFields(newFields ...LogField) Logger {
+func (l nullLogger) WithFields(newFields ...Field) Logger {
 	existingLen := 0
 
 	existingFields := l.Fields()
@@ -150,7 +150,7 @@ func (l nullLogger) WithFields(newFields ...LogField) Logger {
 		existingLen = existingFields.Len()
 	}
 
-	fields := make([]LogField, 0, existingLen+len(newFields))
+	fields := make([]Field, 0, existingLen+len(newFields))
 	for i := 0; i < existingLen; i++ {
 		fields = append(fields, existingFields.ValueAt(i))
 	}
@@ -163,13 +163,13 @@ var SimpleLogger = NewLogger(os.Stdout)
 
 type writerLogger struct {
 	writer io.Writer
-	fields LogFields
+	fields LoggerFields
 }
 
 const writerLoggerStamp = "15:04:05.000000"
 
 // NewLogger returns a Logger that writes to the given writer.
-func NewLogger(writer io.Writer, fields ...LogField) Logger {
+func NewLogger(writer io.Writer, fields ...Field) Logger {
 	return &writerLogger{writer, Fields(fields)}
 }
 
@@ -183,7 +183,7 @@ func (l writerLogger) Fatal(msg string) {
 	os.Exit(1)
 }
 
-func (l writerLogger) Enabled(_ LogLevel) bool                { return true }
+func (l writerLogger) Enabled(_ Level) bool                   { return true }
 func (l writerLogger) Errorf(msg string, args ...interface{}) { l.printfn("E", msg, args...) }
 func (l writerLogger) Error(msg string)                       { l.printfn("E", msg) }
 func (l writerLogger) Warnf(msg string, args ...interface{})  { l.printfn("W", msg, args...) }
@@ -202,13 +202,13 @@ func (l writerLogger) printfn(prefix, msg string, args ...interface{}) {
 	fmt.Fprintf(l.writer, "%s[%s] %s %v\n", ft, prefix, fma, l.fields)
 }
 
-func (l writerLogger) Fields() LogFields {
+func (l writerLogger) Fields() LoggerFields {
 	return l.fields
 }
 
-func (l writerLogger) WithFields(newFields ...LogField) Logger {
+func (l writerLogger) WithFields(newFields ...Field) Logger {
 	existingFields := l.Fields()
-	fields := make([]LogField, 0, existingFields.Len()+1)
+	fields := make([]Field, 0, existingFields.Len()+1)
 	for i := 0; i < existingFields.Len(); i++ {
 		fields = append(fields, existingFields.ValueAt(i))
 	}
@@ -216,136 +216,136 @@ func (l writerLogger) WithFields(newFields ...LogField) Logger {
 	return &writerLogger{l.writer, Fields(fields)}
 }
 
-// LogLevel is the level of logging used by LevelLogger.
-type LogLevel int
+// Level is the level of logging used by LevelLogger.
+type Level int
 
-// The minimum level that will be logged. e.g. LogLevelError only logs errors and fatals.
+// The minimum level that will be logged. e.g. LevelError only logs errors and fatals.
 const (
-	LogLevelAll LogLevel = iota
-	LogLevelDebug
-	LogLevelInfo
-	LogLevelWarn
-	LogLevelError
-	LogLevelFatal
+	LevelAll Level = iota
+	LevelDebug
+	LevelInfo
+	LevelWarn
+	LevelError
+	LevelFatal
 )
 
-var logLevels = []LogLevel{
-	LogLevelAll,
-	LogLevelDebug,
-	LogLevelInfo,
-	LogLevelWarn,
-	LogLevelError,
-	LogLevelFatal,
+var levels = []Level{
+	LevelAll,
+	LevelDebug,
+	LevelInfo,
+	LevelWarn,
+	LevelError,
+	LevelFatal,
 }
 
-func (l LogLevel) String() string {
+func (l Level) String() string {
 	switch l {
-	case LogLevelAll:
+	case LevelAll:
 		return "all"
-	case LogLevelDebug:
+	case LevelDebug:
 		return "debug"
-	case LogLevelInfo:
+	case LevelInfo:
 		return "info"
-	case LogLevelWarn:
+	case LevelWarn:
 		return "warn"
-	case LogLevelError:
+	case LevelError:
 		return "error"
-	case LogLevelFatal:
+	case LevelFatal:
 		return "fatal"
 	}
 	return ""
 }
 
-// ParseLogLevel parses a log level string to log level.
-func ParseLogLevel(level string) (LogLevel, error) {
+// ParseLevel parses a log level string to log level.
+func ParseLevel(level string) (Level, error) {
 	level = strings.ToLower(level)
-	for _, l := range logLevels {
+	for _, l := range levels {
 		if strings.ToLower(l.String()) == level {
 			return l, nil
 		}
 	}
-	return LogLevel(0), fmt.Errorf("unrecognized log level: %s", level)
+	return Level(0), fmt.Errorf("unrecognized log level: %s", level)
 }
 
 type levelLogger struct {
 	logger Logger
-	level  LogLevel
+	level  Level
 }
 
 // NewLevelLogger returns a logger that only logs messages with a minimum of level.
-func NewLevelLogger(logger Logger, level LogLevel) Logger {
+func NewLevelLogger(logger Logger, level Level) Logger {
 	return &levelLogger{logger, level}
 }
 
-func (l levelLogger) Enabled(level LogLevel) bool {
+func (l levelLogger) Enabled(level Level) bool {
 	return l.level <= level
 }
 
 func (l levelLogger) Fatalf(msg string, args ...interface{}) {
-	if l.level <= LogLevelFatal {
+	if l.level <= LevelFatal {
 		l.logger.Fatalf(msg, args...)
 	}
 }
 
 func (l levelLogger) Fatal(msg string) {
-	if l.level <= LogLevelFatal {
+	if l.level <= LevelFatal {
 		l.logger.Fatal(msg)
 	}
 }
 
 func (l levelLogger) Errorf(msg string, args ...interface{}) {
-	if l.level <= LogLevelError {
+	if l.level <= LevelError {
 		l.logger.Errorf(msg, args...)
 	}
 }
 
 func (l levelLogger) Error(msg string) {
-	if l.level <= LogLevelError {
+	if l.level <= LevelError {
 		l.logger.Error(msg)
 	}
 }
 
 func (l levelLogger) Warnf(msg string, args ...interface{}) {
-	if l.level <= LogLevelWarn {
+	if l.level <= LevelWarn {
 		l.logger.Warnf(msg, args...)
 	}
 }
 
 func (l levelLogger) Warn(msg string) {
-	if l.level <= LogLevelWarn {
+	if l.level <= LevelWarn {
 		l.logger.Warn(msg)
 	}
 }
 
 func (l levelLogger) Infof(msg string, args ...interface{}) {
-	if l.level <= LogLevelInfo {
+	if l.level <= LevelInfo {
 		l.logger.Infof(msg, args...)
 	}
 }
 
 func (l levelLogger) Info(msg string) {
-	if l.level <= LogLevelInfo {
+	if l.level <= LevelInfo {
 		l.logger.Info(msg)
 	}
 }
 
 func (l levelLogger) Debugf(msg string, args ...interface{}) {
-	if l.level <= LogLevelDebug {
+	if l.level <= LevelDebug {
 		l.logger.Debugf(msg, args...)
 	}
 }
 
 func (l levelLogger) Debug(msg string) {
-	if l.level <= LogLevelDebug {
+	if l.level <= LevelDebug {
 		l.logger.Debug(msg)
 	}
 }
 
-func (l levelLogger) Fields() LogFields {
+func (l levelLogger) Fields() LoggerFields {
 	return l.logger.Fields()
 }
 
-func (l levelLogger) WithFields(fields ...LogField) Logger {
+func (l levelLogger) WithFields(fields ...Field) Logger {
 	return &levelLogger{
 		logger: l.logger.WithFields(fields...),
 		level:  l.level,

--- a/log/logger.go
+++ b/log/logger.go
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 // Package xlog implements a logging package.
-package xlog
+package log
 
 import (
 	"fmt"

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -28,6 +28,6 @@ import (
 
 func TestNullLogger(t *testing.T) {
 	require.NotPanics(t, func() {
-		NullLogger.WithFields(NewLogField("key", "value")).Info("msg")
+		NullLogger.WithFields(NewField("key", "value")).Info("msg")
 	})
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xlog
+package log
 
 import (
 	"testing"

--- a/net/example_test.go
+++ b/net/example_test.go
@@ -18,14 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xnet_test
+package net_test
 
 import (
 	"io"
 	"log"
 	"net"
 
-	"github.com/m3db/m3x/net"
+	xnet "github.com/m3db/m3x/net"
 	"github.com/m3db/m3x/retry"
 )
 
@@ -39,7 +39,7 @@ func ExampleStartForeverAcceptLoop() {
 
 	// Start accepting incoming connections.
 	var (
-		opts          = xretry.NewOptions()
+		opts          = retry.NewOptions()
 		connCh, errCh = xnet.StartAcceptLoop(l, opts)
 	)
 

--- a/net/server.go
+++ b/net/server.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xnet implements functions for running network servers.
-package xnet
+// Package net implements functions for running network servers.
+package net
 
 import (
 	"net"
@@ -32,11 +32,11 @@ import (
 // returning accepted connections via a channel while handling
 // temporary network errors. Fatal errors are returned via the
 // error channel with the listener closed on return.
-func StartAcceptLoop(l net.Listener, rOpts xretry.Options) (<-chan net.Conn, <-chan error) {
+func StartAcceptLoop(l net.Listener, rOpts retry.Options) (<-chan net.Conn, <-chan error) {
 	var (
 		connCh  = make(chan net.Conn)
 		errCh   = make(chan error)
-		retrier = xretry.NewRetrier(rOpts)
+		retrier = retry.NewRetrier(rOpts)
 	)
 
 	go func() {
@@ -55,7 +55,7 @@ func StartAcceptLoop(l net.Listener, rOpts xretry.Options) (<-chan net.Conn, <-c
 					return ne
 				}
 				// Otherwise it's a non-retryable error.
-				return xerrors.NewNonRetryableError(connErr)
+				return errors.NewNonRetryableError(connErr)
 			}); err != nil {
 				close(connCh)
 				errCh <- err
@@ -74,6 +74,6 @@ func StartAcceptLoop(l net.Listener, rOpts xretry.Options) (<-chan net.Conn, <-c
 // accepted connections via a channel while handling
 // temporary network errors. Fatal errors are returned via the
 // error channel with the listener closed on return.
-func StartForeverAcceptLoop(l net.Listener, rOpts xretry.Options) (<-chan net.Conn, <-chan error) {
+func StartForeverAcceptLoop(l net.Listener, rOpts retry.Options) (<-chan net.Conn, <-chan error) {
 	return StartAcceptLoop(l, rOpts.SetForever(true))
 }

--- a/net/server_test.go
+++ b/net/server_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xnet
+package net
 
 import (
 	"fmt"
@@ -44,7 +44,7 @@ func TestStartAcceptLoop(t *testing.T) {
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.Nil(t, err)
-	connCh, errCh := StartForeverAcceptLoop(l, xretry.NewOptions())
+	connCh, errCh := StartForeverAcceptLoop(l, retry.NewOptions())
 
 	wgServer.Add(1)
 	go func() {

--- a/pool/heap.go
+++ b/pool/heap.go
@@ -28,7 +28,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/m3db/m3x/log"
+	xlog "github.com/m3db/m3x/log"
 
 	"github.com/uber-go/tally"
 )

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -18,9 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xpprof provides a function for registering a HTTP handler for pprof
+// Package pprof provides a function for registering a HTTP handler for pprof
 // endpoints.
-package xpprof
+package pprof
 
 import (
 	"net/http"

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xpprof
+package pprof
 
 import (
 	"net/http"

--- a/retry/config.go
+++ b/retry/config.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xretry
+package retry
 
 import (
 	"time"

--- a/retry/config_test.go
+++ b/retry/config_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xretry
+package retry
 
 import (
 	"testing"

--- a/retry/example_test.go
+++ b/retry/example_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xretry_test
+package retry_test
 
 import (
 	"context"
@@ -31,8 +31,8 @@ import (
 
 func ExampleRetrier() {
 	var (
-		opts    = xretry.NewOptions()
-		retrier = xretry.NewRetrier(opts)
+		opts    = retry.NewOptions()
+		retrier = retry.NewRetrier(opts)
 		context = context.Background()
 	)
 

--- a/retry/options.go
+++ b/retry/options.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xretry
+package retry
 
 import (
 	"math"

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -18,14 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xretry
+package retry
 
 import (
 	"errors"
 	"math/rand"
 	"time"
 
-	"github.com/m3db/m3x/errors"
+	xerrors "github.com/m3db/m3x/errors"
 
 	"github.com/uber-go/tally"
 )

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xretry
+package retry
 
 import (
 	"errors"

--- a/retry/types.go
+++ b/retry/types.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xretry provides utilities for retrying functions.
-package xretry
+// Package retry provides utilities for retrying functions.
+package retry
 
 import (
 	"time"
@@ -31,12 +31,12 @@ import (
 
 // RetryableError returns a retryable error.
 func RetryableError(err error) error {
-	return xerrors.NewRetryableError(err)
+	return errors.NewRetryableError(err)
 }
 
 // NonRetryableError returns a non-retryable error.
 func NonRetryableError(err error) error {
-	return xerrors.NewNonRetryableError(err)
+	return errors.NewNonRetryableError(err)
 }
 
 // Fn is a function that can be retried.

--- a/server/example_test.go
+++ b/server/example_test.go
@@ -18,13 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xserver_test
+package server_test
 
 import (
 	"log"
 	"net"
 
-	"github.com/m3db/m3x/server"
+	xserver "github.com/m3db/m3x/server"
 )
 
 type simpleHandler struct{}

--- a/server/options.go
+++ b/server/options.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xserver
+package server
 
 import (
 	"time"
@@ -45,10 +45,10 @@ type Options interface {
 	InstrumentOptions() instrument.Options
 
 	// SetRetryOptions sets the retry options
-	SetRetryOptions(value xretry.Options) Options
+	SetRetryOptions(value retry.Options) Options
 
 	// RetryOptions returns the retry options
-	RetryOptions() xretry.Options
+	RetryOptions() retry.Options
 
 	// SetTCPConnectionKeepAlive sets the keep alive state for tcp connections.
 	SetTCPConnectionKeepAlive(value bool) Options
@@ -68,7 +68,7 @@ type Options interface {
 
 type options struct {
 	instrumentOpts               instrument.Options
-	retryOpts                    xretry.Options
+	retryOpts                    retry.Options
 	tcpConnectionKeepAlive       bool
 	tcpConnectionKeepAlivePeriod time.Duration
 }
@@ -77,7 +77,7 @@ type options struct {
 func NewOptions() Options {
 	return &options{
 		instrumentOpts:               instrument.NewOptions(),
-		retryOpts:                    xretry.NewOptions(),
+		retryOpts:                    retry.NewOptions(),
 		tcpConnectionKeepAlive:       defaultTCPConnectionKeepAlive,
 		tcpConnectionKeepAlivePeriod: defaultTCPConnectionKeepAlivePeriod,
 	}
@@ -93,13 +93,13 @@ func (o *options) InstrumentOptions() instrument.Options {
 	return o.instrumentOpts
 }
 
-func (o *options) SetRetryOptions(value xretry.Options) Options {
+func (o *options) SetRetryOptions(value retry.Options) Options {
 	opts := *o
 	opts.retryOpts = value
 	return &opts
 }
 
-func (o *options) RetryOptions() xretry.Options {
+func (o *options) RetryOptions() retry.Options {
 	return o.retryOpts
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -162,7 +162,7 @@ func (s *server) serve() {
 		}
 	}
 	err := <-errCh
-	s.log.WithFields(log.NewLogErrField(err)).
+	s.log.WithFields(log.NewErrField(err)).
 		Error("server unexpectedly closed")
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xserver implements a network server.
-package xserver
+// Package server implements a network server.
+package server
 
 import (
 	"net"
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3x/log"
-	"github.com/m3db/m3x/net"
+	xnet "github.com/m3db/m3x/net"
 	"github.com/m3db/m3x/retry"
 
 	"github.com/uber-go/tally"
@@ -77,8 +77,8 @@ type server struct {
 
 	address                      string
 	listener                     net.Listener
-	log                          xlog.Logger
-	retryOpts                    xretry.Options
+	log                          log.Logger
+	retryOpts                    retry.Options
 	reportInterval               time.Duration
 	tcpConnectionKeepAlive       bool
 	tcpConnectionKeepAlivePeriod time.Duration
@@ -162,7 +162,7 @@ func (s *server) serve() {
 		}
 	}
 	err := <-errCh
-	s.log.WithFields(xlog.NewLogErrField(err)).
+	s.log.WithFields(log.NewLogErrField(err)).
 		Error("server unexpectedly closed")
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xserver
+package server
 
 import (
 	"fmt"
@@ -44,7 +44,7 @@ func testServer(addr string) (*server, *mockHandler, *int32, *int32) {
 		numRemoved int32
 	)
 
-	opts := NewOptions().SetRetryOptions(xretry.NewOptions().SetMaxRetries(2))
+	opts := NewOptions().SetRetryOptions(retry.NewOptions().SetMaxRetries(2))
 	opts = opts.SetInstrumentOptions(opts.InstrumentOptions().SetReportInterval(time.Second))
 
 	h := newMockHandler()

--- a/sync/example_test.go
+++ b/sync/example_test.go
@@ -18,14 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xsync_test
+package sync_test
 
 import (
 	"fmt"
 	"log"
 	"sync"
 
-	"github.com/m3db/m3x/sync"
+	xsync "github.com/m3db/m3x/sync"
 )
 
 type response struct {

--- a/sync/worker_pool.go
+++ b/sync/worker_pool.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xsync implements synchronization facililites such as worker pools.
-package xsync
+// Package sync implements synchronization facililites such as worker pools.
+package sync
 
 import (
 	"time"

--- a/sync/worker_pool_test.go
+++ b/sync/worker_pool_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xsync
+package sync
 
 import (
 	"sync"

--- a/tcp/tcp.go
+++ b/tcp/tcp.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xtcp implements a tcp listener.
-package xtcp
+// Package tcp implements a tcp listener.
+package tcp
 
 import (
 	"net"

--- a/time/duration.go
+++ b/time/duration.go
@@ -16,7 +16,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import (
 	"errors"

--- a/time/duration_test.go
+++ b/time/duration_test.go
@@ -16,7 +16,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import (
 	"testing"

--- a/time/range.go
+++ b/time/range.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import (
 	"fmt"

--- a/time/range_iter.go
+++ b/time/range_iter.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import "container/list"
 

--- a/time/range_iter_test.go
+++ b/time/range_iter_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import (
 	"container/list"

--- a/time/range_test.go
+++ b/time/range_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import (
 	"testing"

--- a/time/ranges.go
+++ b/time/ranges.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import (
 	"bytes"

--- a/time/ranges_test.go
+++ b/time/ranges_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import (
 	"testing"

--- a/time/time.go
+++ b/time/time.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xtime implement facilities for working with time.
-package xtime
+// Package time implement facilities for working with time.
+package time
 
 import "time"
 

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import (
 	"testing"

--- a/time/unit.go
+++ b/time/unit.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import (
 	"errors"

--- a/time/unit_test.go
+++ b/time/unit_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xtime
+package time
 
 import (
 	"testing"

--- a/unsafe/string.go
+++ b/unsafe/string.go
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xunsafe contains operations that step around the type safety of Go programs.
-package xunsafe
+// Package unsafe contains operations that step around the type safety of Go programs.
+package unsafe
 
 import (
 	"reflect"

--- a/unsafe/string_benchmark_test.go
+++ b/unsafe/string_benchmark_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xunsafe
+package unsafe
 
 import (
 	"bytes"

--- a/unsafe/string_test.go
+++ b/unsafe/string_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xunsafe
+package unsafe
 
 import (
 	"bytes"

--- a/watch/source.go
+++ b/watch/source.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xwatch
+package watch
 
 import (
 	"errors"
@@ -40,7 +40,7 @@ type SourceInput interface {
 
 // Source polls data by calling SourcePollFn and notifies its watches on updates.
 type Source interface {
-	xclose.SimpleCloser
+	close.SimpleCloser
 
 	// Get returns the latest value.
 	Get() interface{}
@@ -50,7 +50,7 @@ type Source interface {
 }
 
 // NewSource returns a new Source.
-func NewSource(input SourceInput, logger xlog.Logger) Source {
+func NewSource(input SourceInput, logger log.Logger) Source {
 	s := &source{
 		input:  input,
 		w:      NewWatchable(),
@@ -67,7 +67,7 @@ type source struct {
 	input  SourceInput
 	w      Watchable
 	closed bool
-	logger xlog.Logger
+	logger log.Logger
 }
 
 func (s *source) run() {

--- a/watch/source_test.go
+++ b/watch/source_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xwatch
+package watch
 
 import (
 	"errors"
@@ -42,7 +42,9 @@ func TestSource(t *testing.T) {
 }
 
 func testSource(t *testing.T, errAfter int32, closeAfter int32, watchNum int) {
-	s := NewSource(&testSourceInput{callCount: 0, errAfter: errAfter, closeAfter: closeAfter}, xlog.SimpleLogger)
+	s := NewSource(
+		&testSourceInput{callCount: 0, errAfter: errAfter, closeAfter: closeAfter}, log.SimpleLogger,
+	)
 
 	var wg sync.WaitGroup
 

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -18,14 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package xwatch provides utilities for watching resources for changes.
-package xwatch
+// Package watch provides utilities for watching resources for changes.
+package watch
 
 import (
 	"errors"
 	"sync"
 
-	"github.com/m3db/m3x/close"
+	xclose "github.com/m3db/m3x/close"
 )
 
 var errClosed = errors.New("closed")

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package xwatch
+package watch
 
 import (
 	"fmt"


### PR DESCRIPTION
This package addresses #95 and ensures that we use a consistent naming approach for our packages by removing the `x` from all packages which begin with one. Will take a stab at updating all packages that depend on `m3x` when this lands.