### PR TITLE
[glide] Only include direct dependencies and use semantic versions where available

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 50a0b59635ffd9cd3f6bd65a7f6a415f0f3a9a82d4f40b997585e04a4bcf2e86
-updated: 2017-08-20T15:45:39.86828054-04:00
+hash: 2bd54f77e2cac4a0b501cc4032ea9e21a06002248a54cb4a11f33e74cb2410a3
+updated: 2017-09-16T09:13:52.427152982-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -7,16 +7,12 @@ imports:
   - lib/go/thrift
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
-- name: github.com/fortytw2/leaktest
-  version: 3b724c3d7b8729a35bf4e577f71653aec6e53513
 - name: github.com/go-ole/go-ole
   version: de8695c8edbf8236f30d6e1376e20b198a028d42
   subpackages:
   - oleutil
-- name: github.com/golang/mock
-  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 - name: github.com/shirou/gopsutil
-  version: b62e301a8b9958eebb7299683eb57fab229a9501
+  version: a452de7c734a0fa0f16d2e5725b0fa5934d9fbec
   subpackages:
   - cpu
   - host
@@ -28,20 +24,20 @@ imports:
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
 - name: github.com/StackExchange/wmi
   version: e542ed97d15e640bdc14b5c12162d59e8fc67324
-- name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
-  subpackages:
-  - assert
-  - require
 - name: github.com/uber-go/atomic
-  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
+  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
 - name: github.com/uber-go/tally
-  version: 2605c407d7d219644d03a3680ad7df4779017782
+  version: be9e53c77349ae2dd4b8c03a6dc20ed9a88b9927
   subpackages:
   - m3
   - m3/customtransports
   - m3/thrift
   - m3/thriftudp
+- name: golang.org/x/sys
+  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+  subpackages:
+  - unix
+  - windows
 - name: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - name: gopkg.in/yaml.v2
@@ -51,7 +47,14 @@ testImports:
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/fortytw2/leaktest
+  version: 7dad53304f9614c1c365755c1176a8e876fee3e8
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/stretchr/testify
+  version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
+  subpackages:
+  - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,20 +1,8 @@
 package: github.com/m3db/m3x
 import:
 
-- package: github.com/facebookgo/clock
-  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
-
-- package: github.com/golang/mock
-  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
-
-- package: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
-  subpackages:
-  - assert
-  - require
-
 - package: github.com/uber-go/tally
-  version: ^3.1.0 # ie >= 3.1.0, < 4.0.0
+  version: ^3.1.0
 
 - package: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
@@ -22,23 +10,19 @@ import:
 - package: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 
-- package: github.com/apache/thrift
-  version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
-
 - package: github.com/uber-go/atomic
-  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
+  version: ^1.2.0
 
 - package: github.com/shirou/gopsutil
-  version: b62e301a8b9958eebb7299683eb57fab229a9501
+  version: ^2.17.08
 
-- package: github.com/go-ole/go-ole
-  version: de8695c8edbf8236f30d6e1376e20b198a028d42
+testImports:
 
-- package: github.com/shirou/w32
-  version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
-
-- package: github.com/StackExchange/wmi
-  version: e542ed97d15e640bdc14b5c12162d59e8fc67324
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - assert
+  - require
 
 - package: github.com/fortytw2/leaktest
-  version: 3b724c3d7b8729a35bf4e577f71653aec6e53513
+  version: ^1.1.0


### PR DESCRIPTION
This PR updates our approach to vendoring dependencies with Glide. Previously, we would almost exclusively use SHA's as opposed to versioned releases and we would vendor transitive dependencies in our `glide.yaml` file in addition to direct dependencies. I think each of these techniques has flaws given the current state of package management in Go however. 

The problem with using SHA's is that Glide has no flexibility in choosing which version of a package to vendor so all vendored packages have to agree on the exact same version. This was highlighted recently when we tried to update the version of `tally` in statsdex. We wanted to use a new feature in a minor release of `tally` but in order to vendor it in statsdex we first had to update each `m3db` repo that statsdex depended on since they were pinned to an older version and did not support minor version changes. By allowing minor version changes between packages we can allow packages to update when they want to pull in new features or updates, and still rely on the API stability of the major version so that packages that do not need these new features will continue to work as expected.

The second way I think we can improve how we use Glide is to not vendor transitive dependencies in our `glide.yaml` files. When we add transitive dependencies to `glide.yaml` there is no way to distinguish them as such. Consequently, when updating dependencies we have to remember which ones depend on others so that we can update them accordingly. Instead, given that package mangement has matured greatly in the Go ecosystem and there are [official tools in development](https://github.com/golang/dep) we should instead allow packages to manage their own dependencies and not introduce them into `glide.yaml`. Under this approach we still have reproducible builds since `glide.lock` tracks the exact version of a package being used at any given time, and `glide install` will only install those versions. Furthermore, Glide offers the ability to update only a subset of packages (`glide update -v <package>`) so that when we do update dependencies we can be selective about which ones we choose.

Anyway, that's a lot of rambling, let me know what you think @xichen2020 @prateek @cw9 