### PR TITLE
Add mumur3 128-bit as a more efficient alternative for hashing ids

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 50a0b59635ffd9cd3f6bd65a7f6a415f0f3a9a82d4f40b997585e04a4bcf2e86
-updated: 2017-08-20T15:45:39.86828054-04:00
+updated: 2017-09-27T11:06:16.549595088-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -26,6 +26,8 @@ imports:
   - process
 - name: github.com/shirou/w32
   version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
+- name: github.com/spaolacci/murmur3
+  version: 0d12bf811670bf6a1a63828dfbd003eded177fce
 - name: github.com/StackExchange/wmi
   version: e542ed97d15e640bdc14b5c12162d59e8fc67324
 - name: github.com/stretchr/testify
@@ -36,7 +38,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
-  version: 2605c407d7d219644d03a3680ad7df4779017782
+  version: be9e53c77349ae2dd4b8c03a6dc20ed9a88b9927
   subpackages:
   - m3
   - m3/customtransports

--- a/glide.yaml
+++ b/glide.yaml
@@ -42,3 +42,6 @@ import:
 
 - package: github.com/fortytw2/leaktest
   version: 3b724c3d7b8729a35bf4e577f71653aec6e53513
+
+- package: github.com/spaolacci/murmur3
+  version: 0d12bf811670bf6a1a63828dfbd003eded177fce

--- a/id/hash.go
+++ b/id/hash.go
@@ -21,7 +21,11 @@
 // Package id provides utilities for generating ID's from hash functions.
 package id
 
-import "crypto/md5"
+import (
+	"crypto/md5"
+
+	"github.com/spaolacci/murmur3"
+)
 
 // Hash represents a form of ID suitable to be used as map keys.
 type Hash [md5.Size]byte
@@ -29,4 +33,13 @@ type Hash [md5.Size]byte
 // HashFn is the default hashing implementation for IDs.
 func HashFn(data []byte) Hash {
 	return md5.Sum(data)
+}
+
+// Hash128 is a 128-bit hash of an ID consisting of two unsigned 64-bit ints.
+type Hash128 [2]uint64
+
+// Murmur3Hash128 computes the 128-bit hash of an id.
+func Murmur3Hash128(data []byte) Hash128 {
+	h0, h1 := murmur3.Sum128(data)
+	return Hash128{h0, h1}
 }

--- a/id/hash_bench_test.go
+++ b/id/hash_bench_test.go
@@ -36,40 +36,66 @@ var (
 	testShortID, testMediumID, testLongID []byte
 )
 
-func BenchmarkMD5ShortID(b *testing.B) {
+func benchmarkMD5ShortID(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		HashFn(testShortID)
 	}
 }
 
-func BenchmarkMD5MediumID(b *testing.B) {
+func benchmarkMD5MediumID(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		HashFn(testMediumID)
 	}
 }
 
-func BenchmarkMD5LongID(b *testing.B) {
+func benchmarkMD5LongID(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		HashFn(testLongID)
 	}
 }
 
-func BenchmarkMurmur3Hash128ShortID(b *testing.B) {
+func benchmarkMurmur3Hash128ShortID(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Murmur3Hash128(testShortID)
 	}
 }
 
-func BenchmarkMurmur3Hash128MediumID(b *testing.B) {
+func benchmarkMurmur3Hash128MediumID(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Murmur3Hash128(testMediumID)
 	}
 }
 
-func BenchmarkMurmur3Hash128LongID(b *testing.B) {
+func benchmarkMurmur3Hash128LongID(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Murmur3Hash128(testLongID)
 	}
+}
+
+func BenchmarkHashingFunctions(b *testing.B) {
+	setup()
+
+	benchmarks := []struct {
+		description string
+		fn          func(b *testing.B)
+	}{
+		{description: "Benchmark MD5 for short id", fn: benchmarkMD5ShortID},
+		{description: "Benchmark MD5 for medium id", fn: benchmarkMD5MediumID},
+		{description: "Benchmark MD5 for long id", fn: benchmarkMD5LongID},
+		{description: "Benchmark 128-bit murmur3 hash for short id", fn: benchmarkMurmur3Hash128ShortID},
+		{description: "Benchmark 128-bit murmur3 hash for medium id", fn: benchmarkMurmur3Hash128MediumID},
+		{description: "Benchmark 128-bit murmur3 for long id", fn: benchmarkMurmur3Hash128LongID},
+	}
+	for _, bench := range benchmarks {
+		b.Run(bench.description, bench.fn)
+	}
+}
+
+func setup() {
+	s := rand.New(rand.NewSource(time.Now().UnixNano()))
+	testShortID = generateTestID(s, testShortIDSize)
+	testMediumID = generateTestID(s, testMediumIDSize)
+	testLongID = generateTestID(s, testLongIDSize)
 }
 
 func generateTestID(s *rand.Rand, size int) []byte {
@@ -78,11 +104,4 @@ func generateTestID(s *rand.Rand, size int) []byte {
 		id[i] = byte(s.Int63() % 256)
 	}
 	return id
-}
-
-func init() {
-	s := rand.New(rand.NewSource(time.Now().UnixNano()))
-	testShortID = generateTestID(s, testShortIDSize)
-	testMediumID = generateTestID(s, testMediumIDSize)
-	testLongID = generateTestID(s, testLongIDSize)
 }

--- a/id/hash_bench_test.go
+++ b/id/hash_bench_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package id
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+const (
+	testShortIDSize  = 8
+	testMediumIDSize = 200
+	testLongIDSize   = 8192
+)
+
+var (
+	testShortID, testMediumID, testLongID []byte
+)
+
+func BenchmarkMD5ShortID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		HashFn(testShortID)
+	}
+}
+
+func BenchmarkMD5MediumID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		HashFn(testMediumID)
+	}
+}
+
+func BenchmarkMD5LongID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		HashFn(testLongID)
+	}
+}
+
+func BenchmarkMurmur3Hash128ShortID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Murmur3Hash128(testShortID)
+	}
+}
+
+func BenchmarkMurmur3Hash128MediumID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Murmur3Hash128(testMediumID)
+	}
+}
+
+func BenchmarkMurmur3Hash128LongID(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Murmur3Hash128(testLongID)
+	}
+}
+
+func generateTestID(s *rand.Rand, size int) []byte {
+	id := make([]byte, size)
+	for i := 0; i < size; i++ {
+		id[i] = byte(s.Int63() % 256)
+	}
+	return id
+}
+
+func init() {
+	s := rand.New(rand.NewSource(time.Now().UnixNano()))
+	testShortID = generateTestID(s, testShortIDSize)
+	testMediumID = generateTestID(s, testMediumIDSize)
+	testLongID = generateTestID(s, testLongIDSize)
+}

--- a/id/hash_test.go
+++ b/id/hash_test.go
@@ -29,5 +29,11 @@ import (
 
 func TestHashFn(t *testing.T) {
 	input := []byte{0x1, 0x2, 0x3}
-	require.Equal(t, HashFn(input), Hash(md5.Sum(input)))
+	require.Equal(t, Hash(md5.Sum(input)), HashFn(input))
+}
+
+func TestMurmur3Hash128(t *testing.T) {
+	input := []byte("foo.bar.baz")
+	expected := Hash128{0xf14b7935f63800a5, 0x57d98c62725b8ebd}
+	require.Equal(t, expected, Murmur3Hash128(input))
 }


### PR DESCRIPTION
cc @jeromefroe @cw9 @prateek 

This PR adds murmur3 as a more efficient and equally good collision-wise alternative to generate 128-bit hashes of ids.

```
BenchmarkMD5ShortID-8               	10000000	       151 ns/op
BenchmarkMD5MediumID-8              	 3000000	       421 ns/op
BenchmarkMD5LongID-8                	  200000	     11567 ns/op
BenchmarkMurmur3Hash128ShortID-8    	100000000	        24.4 ns/op
BenchmarkMurmur3Hash128MediumID-8   	30000000	        50.8 ns/op
BenchmarkMurmur3Hash128LongID-8     	 1000000	      1232 ns/op
```