### PR TITLE
[instrument] Add metric for GC CPU Fraction

### DIFF
--- a/instrument/extended.go
+++ b/instrument/extended.go
@@ -133,6 +133,7 @@ type runtimeMetrics struct {
 	MemoryHeapIdle  tally.Gauge
 	MemoryHeapInuse tally.Gauge
 	MemoryStack     tally.Gauge
+	GCCPUFraction   tally.Gauge
 	NumGC           tally.Counter
 	GcPauseMs       tally.Timer
 	lastNumGC       uint32
@@ -156,6 +157,7 @@ func (r *runtimeMetrics) report(metricsType ExtendedMetricsType) {
 	r.MemoryHeapIdle.Update(float64(memStats.HeapIdle))
 	r.MemoryHeapInuse.Update(float64(memStats.HeapInuse))
 	r.MemoryStack.Update(float64(memStats.StackInuse))
+	r.GCCPUFraction.Update(float64(memStats.GCCPUFraction))
 
 	// memStats.NumGC is a perpetually incrementing counter (unless it wraps at 2^32).
 	num := memStats.NumGC
@@ -219,6 +221,7 @@ func NewExtendedMetricsReporter(
 	r.runtime.MemoryHeapIdle = memoryScope.Gauge("heapidle")
 	r.runtime.MemoryHeapInuse = memoryScope.Gauge("heapinuse")
 	r.runtime.MemoryStack = memoryScope.Gauge("stack")
+	r.runtime.GCCPUFraction = memoryScope.Gauge("gc-cpu-fraction")
 	r.runtime.NumGC = memoryScope.Counter("num-gc")
 	r.runtime.GcPauseMs = memoryScope.Timer("gc-pause-ms")
 	r.runtime.lastNumGC = memstats.NumGC

--- a/instrument/extended.go
+++ b/instrument/extended.go
@@ -157,7 +157,7 @@ func (r *runtimeMetrics) report(metricsType ExtendedMetricsType) {
 	r.MemoryHeapIdle.Update(float64(memStats.HeapIdle))
 	r.MemoryHeapInuse.Update(float64(memStats.HeapInuse))
 	r.MemoryStack.Update(float64(memStats.StackInuse))
-	r.GCCPUFraction.Update(float64(memStats.GCCPUFraction))
+	r.GCCPUFraction.Update(memStats.GCCPUFraction)
 
 	// memStats.NumGC is a perpetually incrementing counter (unless it wraps at 2^32).
 	num := memStats.NumGC


### PR DESCRIPTION
Add a metric for `GCCPUFraction`, which tracks the percentage of total available CPU time that was spent on garbage collection.

cc @xichen2020 @prateek 