### PR TITLE
Improve object pool performance

### DIFF
--- a/pool/object.go
+++ b/pool/object.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"math"
 	"sync/atomic"
-	"time"
 
 	"github.com/uber-go/tally"
 )
@@ -49,6 +48,7 @@ type objectPool struct {
 	refillHighWatermark int
 	filling             int32
 	initialized         int32
+	dice                int32
 	metrics             objectPoolMetrics
 }
 
@@ -145,7 +145,7 @@ func (p *objectPool) Put(obj interface{}) {
 }
 
 func (p *objectPool) trySetGauges() {
-	if time.Now().UnixNano()%sampleObjectPoolLengthEvery == 0 {
+	if atomic.AddInt32(&p.dice, 1)%sampleObjectPoolLengthEvery == 0 {
 		p.setGauges()
 	}
 }

--- a/pool/object_test.go
+++ b/pool/object_test.go
@@ -116,3 +116,16 @@ func TestObjectPoolPutBeforeInitError(t *testing.T) {
 	assert.Error(t, accessErr)
 	assert.Equal(t, errPoolPutBeforeInitialized, accessErr)
 }
+
+func BenchmarkObjectPoolGetPut(b *testing.B) {
+	opts := NewObjectPoolOptions().SetSize(1)
+	pool := NewObjectPool(opts)
+	pool.Init(func() interface{} {
+		return 1
+	})
+
+	for n := 0; n < b.N; n++ {
+		o := pool.Get()
+		pool.Put(o)
+	}
+}


### PR DESCRIPTION
On a frequently accessed pool, we actually spend a lot of time on calling time.Now(), this change should save 600-700ns per operation.

@xichen2020 @robskillington @prateek @jeromefroe 