### PR TITLE
[generics] Don't lint size of map key struct

### DIFF
--- a/generics/hashmap/map.go
+++ b/generics/hashmap/map.go
@@ -93,6 +93,7 @@ type mapOptions struct {
 
 // MapEntry is an entry in the map, this is public to support iterating
 // over the map using a native Go for loop.
+// nolint: maligned
 type MapEntry struct {
 	// key is used to check equality on lookups to resolve collisions
 	key mapKey


### PR DESCRIPTION
Non-zero sized structs which end in a field of zero-length will be padded but if the zero sized field occurs anywhere else in the struct then there won't be any padding ([12884](https://github.com/golang/go/issues/12884) and [9401](https://github.com/golang/go/issues/9401)). Consequently, this PR adds a `nolint` directive to the the `MapEntry` struct to ensure `maligned` doesn't flag `MapEntry` in the case where the map is used as a set (so that the value type of the map is an empty struct).