### PR TITLE
Calling init on worker pool twice no longer blocks

### DIFF
--- a/sync/worker_pool.go
+++ b/sync/worker_pool.go
@@ -56,6 +56,9 @@ func NewWorkerPool(size int) WorkerPool {
 }
 
 func (p *workerPool) Init() {
+	if len(p.workCh) == cap(p.workCh) {
+		return
+	}
 	for i := 0; i < cap(p.workCh); i++ {
 		p.workCh <- struct{}{}
 	}

--- a/sync/worker_pool_test.go
+++ b/sync/worker_pool_test.go
@@ -121,3 +121,23 @@ func TestGoWithTimeout(t *testing.T) {
 
 	require.Equal(t, uint32(testWorkerPoolSize+1), count)
 }
+
+func TestFullWorkerPool(t *testing.T) {
+	var count uint32
+
+	p := NewWorkerPool(testWorkerPoolSize)
+	p.Init()
+	p.Init()
+
+	var wg sync.WaitGroup
+	for i := 0; i < testWorkerPoolSize*2; i++ {
+		wg.Add(1)
+		p.Go(func() {
+			atomic.AddUint32(&count, 1)
+			wg.Done()
+		})
+	}
+	wg.Wait()
+
+	require.Equal(t, uint32(testWorkerPoolSize*2), count)
+}


### PR DESCRIPTION
While working on a service that used two worker pool I accidentally fat fingered and called init twice on the same worker pool. As a result, the service hung forever because we try to blindly push to an already full channel.

This diff checks to see if there are already workers in the channel and if there are just returns. I could see this going either way where we panic/error or silently return. If someone feels strongly about one way or the other I would happy to make a change. 