### PR TITLE
Use strict YAML unmarshal when loading config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,31 +29,41 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-var errNoFilesToLoad = errors.New("attempt to load configuration with no files")
+var errNoFilesToLoad = errors.New("attempt to load config with no files")
 
-// LoadFile loads a config from a file.
-func LoadFile(config interface{}, fname string) error {
-	return loadFiles(config, fname)
+// Options is an options set used when parsing config.
+type Options struct {
+	DisableUnmarshalStrict bool
+	DisableValidate        bool
 }
 
-// loadFiles loads a config from list of files. If value for a property is present
-// in multiple files, the value from the last file will be applied. Validation is
-// done after merging all values.
-// TODO(cw) export this function if needed
-func loadFiles(config interface{}, fnames ...string) error {
-	if len(fnames) == 0 {
+// LoadFile loads a config from a file.
+func LoadFile(config interface{}, file string, opts Options) error {
+	return LoadFiles(config, []string{file}, opts)
+}
+
+// LoadFiles loads a config from list of files. If value for a property is
+// present in multiple files, the value from the last file will be applied.
+// Validation is done after merging all values.
+func LoadFiles(config interface{}, files []string, opts Options) error {
+	if len(files) == 0 {
 		return errNoFilesToLoad
 	}
-	for _, fname := range fnames {
-		data, err := ioutil.ReadFile(fname)
+	for _, name := range files {
+		data, err := ioutil.ReadFile(name)
 		if err != nil {
 			return err
 		}
-
-		if err := yaml.UnmarshalStrict(data, config); err != nil {
+		unmarshal := yaml.UnmarshalStrict
+		if opts.DisableUnmarshalStrict {
+			unmarshal = yaml.Unmarshal
+		}
+		if err := unmarshal(data, config); err != nil {
 			return err
 		}
 	}
-
+	if opts.DisableValidate {
+		return nil
+	}
 	return validator.Validate(config)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,7 @@ func loadFiles(config interface{}, fnames ...string) error {
 			return err
 		}
 
-		if err := yaml.Unmarshal(data, config); err != nil {
+		if err := yaml.UnmarshalStrict(data, config); err != nil {
 			return err
 		}
 	}

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -33,7 +33,8 @@ type configuration struct {
 
 func ExampleLoadFile() {
 	var cfg configuration
-	if err := config.LoadFile(&cfg, "testdata/conf.yaml"); err != nil {
+	file := "testdata/conf.yaml"
+	if err := config.LoadFile(&cfg, file, config.Options{}); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Printf("listenAddress: %s\n", cfg.ListenAddress)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a26ba0abf3c7a26636c280db099658512a2ba7cff3dab4ab2b207d2bfabfd13e
-updated: 2018-04-16T15:52:38.885285-04:00
+hash: fd240aa3ae2255418c6f569f8d07ec59c46b5dfe9da60f007a70c6364dd918bc
+updated: 2018-04-24T11:52:45.597572-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -49,7 +49,7 @@ imports:
 - name: gopkg.in/validator.v2
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/davecgh/go-spew
   version: adab96458c51a58dc1783b3335dcce5461522e75

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,7 @@ import:
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
 
 - package: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a


### PR DESCRIPTION
The current unmarshalling is susceptible to setting keys that are missing in the config resulting in unexpected default values when the key used is wrong.

This change makes config loading use the new `yaml.UnmarshalStrict` method now available in `gopkg.in/yaml.v2`.