### PR TITLE
Expose the math for calculating backoff time

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -159,7 +159,7 @@ func (r *retrier) BackoffNanos(retry int) int64 {
 		backoff = half + rand.Int63n(half)
 	}
 	if retry >= 1 {
-		backoff = int64(float64(backoff) * math.Pow(float64(r.backoffFactor), float64(retry)))
+		backoff = int64(float64(backoff) * math.Pow(r.backoffFactor, float64(retry)))
 	}
 	if maxBackoff := r.maxBackoff.Nanoseconds(); backoff > maxBackoff {
 		backoff = maxBackoff

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -152,14 +152,14 @@ func (r *retrier) attempt(continueFn ContinueFn, fn Fn) error {
 	return err
 }
 
-func (r *retrier) BackoffNanos(try int) int64 {
+func (r *retrier) BackoffNanos(retry int) int64 {
 	backoff := r.initialBackoff.Nanoseconds()
 	if r.jitter {
 		half := backoff / 2
 		backoff = half + rand.Int63n(half)
 	}
-	if try >= 1 {
-		backoff = int64(float64(backoff) * math.Pow(float64(r.backoffFactor), float64(try)))
+	if retry >= 1 {
+		backoff = int64(float64(backoff) * math.Pow(float64(r.backoffFactor), float64(retry)))
 	}
 	if maxBackoff := r.maxBackoff.Nanoseconds(); backoff > maxBackoff {
 		backoff = maxBackoff

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -161,12 +161,12 @@ func BackoffNanos(
 	maxBackoff time.Duration,
 ) int64 {
 	backoff := initialBackoff.Nanoseconds()
+	if retry >= 1 {
+		backoff = int64(float64(backoff) * math.Pow(backoffFactor, float64(retry)))
+	}
 	if jitter {
 		half := backoff / 2
 		backoff = half + rand.Int63n(half)
-	}
-	if retry >= 1 {
-		backoff = int64(float64(backoff) * math.Pow(backoffFactor, float64(retry)))
 	}
 	if maxBackoff := maxBackoff.Nanoseconds(); backoff > maxBackoff {
 		backoff = maxBackoff

--- a/retry/types.go
+++ b/retry/types.go
@@ -47,6 +47,9 @@ type ContinueFn func(attempt int) bool
 
 // Retrier is a executor that can retry attempts on executing methods.
 type Retrier interface {
+	// BackoffNanos calculates the backoff for a retry in nanoseconds.
+	BackoffNanos(retry int) int64
+
 	// Attempt will attempt to perform a function with retries.
 	Attempt(fn Fn) error
 

--- a/retry/types.go
+++ b/retry/types.go
@@ -47,9 +47,6 @@ type ContinueFn func(attempt int) bool
 
 // Retrier is a executor that can retry attempts on executing methods.
 type Retrier interface {
-	// BackoffNanos calculates the backoff for a retry in nanoseconds.
-	BackoffNanos(retry int) int64
-
 	// Attempt will attempt to perform a function with retries.
 	Attempt(fn Fn) error
 


### PR DESCRIPTION
This pr exposes the function to return the backoff nanoseconds for a given retry, so I can reuse the math in a case where I don't actually need the attempt().

This pr changes the underlying math slightly.

@robskillington @xichen2020 @prateek @jeromefroe 