### PR TITLE
Avoid negative result in retry backoff

### DIFF
--- a/retry/config.go
+++ b/retry/config.go
@@ -29,13 +29,13 @@ import (
 // Configuration configures options for retry attempts.
 type Configuration struct {
 	// Initial retry backoff.
-	InitialBackoff time.Duration `yaml:"initialBackoff"`
+	InitialBackoff time.Duration `yaml:"initialBackoff" validate:"min=0"`
 
 	// Backoff factor for exponential backoff.
-	BackoffFactor float64 `yaml:"backoffFactor"`
+	BackoffFactor float64 `yaml:"backoffFactor" validate:"min=0"`
 
 	// Maximum backoff time.
-	MaxBackoff time.Duration `yaml:"maxBackoff"`
+	MaxBackoff time.Duration `yaml:"maxBackoff" validate:"min=0"`
 
 	// Maximum number of retry attempts.
 	MaxRetries int `yaml:"maxRetries"`

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -162,10 +162,11 @@ func BackoffNanos(
 ) int64 {
 	backoff := initialBackoff.Nanoseconds()
 	if retry >= 1 {
-		backoff = int64(float64(backoff) * math.Pow(backoffFactor, float64(retry-1)))
-	}
-	if backoff < 0 {
-		return maxBackoff.Nanoseconds()
+		backoffFloat64 := float64(backoff) * math.Pow(backoffFactor, float64(retry-1))
+		if backoffFloat64 > math.MaxInt64 {
+			return maxBackoff.Nanoseconds()
+		}
+		backoff = int64(backoffFloat64)
 	}
 	// Validate the value of backoff to make sure Int63n() does not panic.
 	if jitter && backoff >= 2 {

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -163,6 +163,7 @@ func BackoffNanos(
 	backoff := initialBackoff.Nanoseconds()
 	if retry >= 1 {
 		backoffFloat64 := float64(backoff) * math.Pow(backoffFactor, float64(retry-1))
+		// math.Inf is also larger than math.MaxInt64.
 		if backoffFloat64 > math.MaxInt64 {
 			return maxBackoff.Nanoseconds()
 		}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -164,6 +164,9 @@ func BackoffNanos(
 	if retry >= 1 {
 		backoff = int64(float64(backoff) * math.Pow(backoffFactor, float64(retry-1)))
 	}
+	if backoff < 0 {
+		return maxBackoff.Nanoseconds()
+	}
 	// Validate the value of backoff to make sure Int63n() does not panic.
 	if jitter && backoff >= 2 {
 		half := backoff / 2

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -200,17 +200,16 @@ func TestRetryForever(t *testing.T) {
 	assert.Equal(t, time.Duration(1023*time.Second), totalSlept)
 }
 
-func TestBackoffNoPanic(t *testing.T) {
+func TestBackoffValidResult(t *testing.T) {
 	seed := time.Now().UnixNano()
 	parameters := gopter.DefaultTestParameters()
 	parameters.Rng = rand.New(rand.NewSource(seed))
 	parameters.MinSuccessfulTests = 10000
 	props := gopter.NewProperties(parameters)
 
-	props.Property("No panic", prop.ForAll(
+	props.Property("Valid result", prop.ForAll(
 		func(retry int, jitter bool, backoffFactor float64, initialBackoff, maxBackoff int64) bool {
-			BackoffNanos(retry, jitter, backoffFactor, time.Duration(initialBackoff), time.Duration(maxBackoff))
-			return true
+			return BackoffNanos(retry, jitter, backoffFactor, time.Duration(initialBackoff), time.Duration(maxBackoff)) >= 0
 		},
 		gen.IntRange(-100, 1000),
 		gen.Bool(),

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -213,7 +213,7 @@ func TestBackoffValidResult(t *testing.T) {
 		},
 		gen.IntRange(-100, 1000),
 		gen.Bool(),
-		gen.Float64Range(-100, 1000),
+		gen.Float64Range(0, 1000),
 		gen.Int64Range(0, math.MaxInt64),
 		gen.Int64Range(0, math.MaxInt64),
 	))


### PR DESCRIPTION
This pr fixes a bug in the backoff calculation which could generate negative result after many retries: for example with the following input:
retry: 50
jitter: true/false
backoffFactor: 2.0
initialBackoff: 10ms
maxBackoff: 50ms

The reason is that 10^7 * math.Pow(2.0, 50) would overflow when being converted to int64, the original implementation is much less prone to negative backoff result but still possible, luckily time.Sleep is safe(does not panic) on zero or negative duration. 

This pr fixes the issue but could probably use a better way to detect whether the negativity is coming from the math overflow to be more exact.

@xichen2020 @prateek @robskillington 