### PR TITLE
Add last error method on MultiError struct

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -247,12 +247,20 @@ func (e MultiError) Add(err error) MultiError {
 	return me
 }
 
-// FinalError returns the final error if any.
+// FinalError returns all concatenated error messages if any.
 func (e MultiError) FinalError() error {
 	if e.err == nil {
 		return nil
 	}
 	return e
+}
+
+// LastError returns the last received error if any.
+func (e MultiError) LastError() error {
+	if e.err == nil {
+		return nil
+	}
+	return e.err
 }
 
 // NumErrors returns the total number of errors.

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -74,6 +74,7 @@ func TestWrapf(t *testing.T) {
 func TestMultiErrorNoError(t *testing.T) {
 	err := NewMultiError()
 	require.Nil(t, err.FinalError())
+	require.Nil(t, err.LastError())
 	require.Equal(t, "", err.Error())
 	require.True(t, err.Empty())
 	require.Equal(t, 0, err.NumErrors())
@@ -85,6 +86,9 @@ func TestMultiErrorOneError(t *testing.T) {
 	final := err.FinalError()
 	require.NotNil(t, final)
 	require.Equal(t, "foo", final.Error())
+	last := err.LastError()
+	require.NotNil(t, last)
+	require.Equal(t, "foo", last.Error())
 	require.False(t, err.Empty())
 	require.Equal(t, 1, err.NumErrors())
 }
@@ -98,6 +102,9 @@ func TestMultiErrorMultipleErrors(t *testing.T) {
 	final := err.FinalError()
 	require.NotNil(t, final)
 	require.Equal(t, final.Error(), "foo\nbar\nbaz")
+	last := err.LastError()
+	require.NotNil(t, last)
+	require.Equal(t, last.Error(), "baz")
 	require.False(t, err.Empty())
 	require.Equal(t, 3, err.NumErrors())
 }

--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func ExampleMultiError() {
-	mutliErr := errors.NewMultiError()
+	multiErr := errors.NewMultiError()
 
 	for i := 0; i < 3; i++ {
 		// Perform some work which may fail.
@@ -36,14 +36,20 @@ func ExampleMultiError() {
 
 		if err != nil {
 			// Add returns a new MultiError.
-			mutliErr = mutliErr.Add(err)
+			multiErr = multiErr.Add(err)
 		}
 	}
 
-	if err := mutliErr.FinalError(); err != nil {
+	if err := multiErr.FinalError(); err != nil {
 		msg := strings.Replace(err.Error(), "\n", "; ", -1)
 		fmt.Println(msg)
 	}
 
-	// Output: error 0; error 1; error 2
+	if err := multiErr.LastError(); err != nil {
+		fmt.Println(err)
+	}
+
+	// Output:
+	// error 0; error 1; error 2
+	// error 2
 }


### PR DESCRIPTION
Allows only the last error to be extracted; useful for cases where any amount of errors leads to a failure, but individual messages are less important. 

Part of a resolution for: https://github.com/m3db/m3/issues/973