### PR TITLE
[hostid] support reading ID from a file

### DIFF
--- a/config/hostid/hostid.go
+++ b/config/hostid/hostid.go
@@ -23,8 +23,17 @@
 package hostid
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultFileCheckInterval = 10 * time.Second
 )
 
 // Resolver is a type of host ID resolver
@@ -38,7 +47,15 @@ const (
 	// EnvironmentResolver resolves host using an environment variable
 	// of which the name is provided in config
 	EnvironmentResolver Resolver = "environment"
+	// KeyValueFileResolver parses a file of key-value pairs (formatted
+	// `KEY=VALUE`) and resolves host ID from a given key.
+	KeyValueFileResolver Resolver = "kvFile"
 )
+
+// IDResolver represents a method of resolving host identity.
+type IDResolver interface {
+	ID() (string, error)
+}
 
 // Configuration is the configuration for resolving a host ID.
 type Configuration struct {
@@ -50,34 +67,151 @@ type Configuration struct {
 
 	// EnvVarName is the environment specified host ID if using environment host ID resolver.
 	EnvVarName *string `yaml:"envVarName"`
+
+	// KVFile is the kv file config.
+	KVFile *KVFileConfig `yaml:"kvFile"`
+}
+
+// KVFileConfig contains the info needed to construct a KeyValueFileResolver.
+type KVFileConfig struct {
+	// Path of the file containing the KV config.
+	Path string `yaml:"path"`
+
+	// Key to search for in the file.
+	Key string `yaml:"key"`
+
+	// Timeout to wait to find the key in the file.
+	Timeout time.Duration `yaml:"timeout"`
+}
+
+func (c Configuration) resolver() (IDResolver, error) {
+	switch c.Resolver {
+	case HostnameResolver:
+		return hostnameResolver{}, nil
+	case ConfigResolver:
+		return &configResolver{value: c.Value}, nil
+	case EnvironmentResolver:
+		return &environmentResolver{envVarName: c.EnvVarName}, nil
+	case KeyValueFileResolver:
+		if c.KVFile == nil {
+			return nil, errors.New("KV file config cannot be nil")
+		}
+		return &kvFile{
+			key:     c.KVFile.Key,
+			path:    c.KVFile.Path,
+			timeout: c.KVFile.Timeout,
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown host ID resolver: resolver=%s",
+		string(c.Resolver))
 }
 
 // Resolve returns the resolved host ID given the configuration.
 func (c Configuration) Resolve() (string, error) {
-	switch c.Resolver {
-	case HostnameResolver:
-		return os.Hostname()
-	case ConfigResolver:
-		if c.Value == nil {
-			err := fmt.Errorf("missing host ID using: resolver=%s",
-				string(c.Resolver))
-			return "", err
-		}
-		return *c.Value, nil
-	case EnvironmentResolver:
-		if c.EnvVarName == nil {
-			err := fmt.Errorf("missing host ID env var name using: resolver=%s",
-				string(c.Resolver))
-			return "", err
-		}
-		v := os.Getenv(*c.EnvVarName)
-		if v == "" {
-			err := fmt.Errorf("missing host ID env var value using: resolver=%s, name=%s",
-				string(c.Resolver), *c.EnvVarName)
-			return "", err
-		}
-		return v, nil
+	r, err := c.resolver()
+	if err != nil {
+		return "", err
 	}
-	return "", fmt.Errorf("unknown host ID resolver: resolver=%s",
-		string(c.Resolver))
+	return r.ID()
+}
+
+type hostnameResolver struct{}
+
+func (hostnameResolver) ID() (string, error) {
+	return os.Hostname()
+}
+
+type configResolver struct {
+	value *string
+}
+
+func (c *configResolver) ID() (string, error) {
+	if c.value == nil {
+		err := fmt.Errorf("missing host ID using: resolver=%s", string(ConfigResolver))
+		return "", err
+	}
+	return *c.value, nil
+}
+
+type environmentResolver struct {
+	envVarName *string
+}
+
+func (c *environmentResolver) ID() (string, error) {
+	if c.envVarName == nil {
+		err := fmt.Errorf("missing host ID env var name using: resolver=%s",
+			string(EnvironmentResolver))
+		return "", err
+	}
+	v := os.Getenv(*c.envVarName)
+	if v == "" {
+		err := fmt.Errorf("missing host ID env var value using: resolver=%s, name=%s",
+			string(EnvironmentResolver), *c.envVarName)
+		return "", err
+	}
+	return v, nil
+}
+
+type kvFile struct {
+	path     string
+	key      string
+	interval time.Duration
+	timeout  time.Duration
+}
+
+// ID attempts to parse an ID from a KV config file. It will optionally wait a
+// timeout to find the value, as in some environments the file may be
+// dynamically generated from external metadata and not immediately available
+// when the instance starts up.
+func (c *kvFile) ID() (string, error) {
+	checkF := func() (string, error) {
+		f, err := os.Open(c.path)
+		if err != nil {
+			return "", err
+		}
+
+		return c.parseKV(f)
+	}
+
+	if c.timeout == 0 {
+		return checkF()
+	}
+
+	interval := c.interval
+	if interval == 0 {
+		interval = defaultFileCheckInterval
+	}
+
+	startT := time.Now()
+	for time.Since(startT) < c.timeout {
+		v, err := checkF()
+		if err == nil {
+			return v, nil
+		}
+
+		time.Sleep(interval)
+	}
+
+	return "", fmt.Errorf("did not find value in %s within %s", c.path, c.timeout)
+}
+
+func (c *kvFile) parseKV(r io.Reader) (string, error) {
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		l := strings.Trim(s.Text(), " ")
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		if parts[0] == c.key {
+			return parts[1], nil
+		}
+	}
+
+	if err := s.Err(); err != nil {
+		return "", err
+	}
+
+	return "", fmt.Errorf("did not find key '%s' in %s", c.key, c.path)
 }

--- a/config/hostid/hostid_test.go
+++ b/config/hostid/hostid_test.go
@@ -160,10 +160,11 @@ func TestFileConfig_Timeout(t *testing.T) {
 
 	defer os.Remove(f.Name())
 
+	timeout := time.Minute
 	c := &file{
 		path:     f.Name(),
 		interval: 10 * time.Millisecond,
-		timeout:  time.Minute,
+		timeout:  &timeout,
 	}
 
 	valC := make(chan string)
@@ -194,10 +195,11 @@ func TestFileConfig_TimeoutErr(t *testing.T) {
 
 	defer os.Remove(f.Name())
 
+	timeout := time.Second
 	c := &file{
 		path:     f.Name(),
 		interval: 10 * time.Millisecond,
-		timeout:  time.Second,
+		timeout:  &timeout,
 	}
 
 	_, err = c.ID()


### PR DESCRIPTION
Under some orchestration systems, such as Kubernetes, we may need to
read host identity from a file on disk that is dynamically populated
with instance metadata. Additionally, this metadata may sometimes be
populated by an external actor and may not be available at startup, so
we provide an optional timeout to wait for it.

As a concrete example, on Kubernetes this supports reading host ID from
pod metadata that is injected using [downward API
volumes](https://git.io/fp4hL). The host ID may not be immediately
populated, but the user can provide a timeout that the instance will
wait for it before failing to start. An example of a pod metadata file
in Kubernetes is:

```
root@matt-test-656988ff69-gk49b:/# cat /etc/podinfo/id
test-id
```